### PR TITLE
Migrate to uv, ruff, and ty

### DIFF
--- a/.github/COPILOT_INSTRUCTIONS.md
+++ b/.github/COPILOT_INSTRUCTIONS.md
@@ -44,8 +44,8 @@ Knocker is a dynamic IP whitelisting service that integrates with reverse proxie
 
 ### Unit Tests
 
-- **Testing Requires `PYTHONPATH`**: Unit tests must be run with `PYTHONPATH=src python3 -m pytest`. Without this, imports will fail.
-- **Run All Tests After Changes**: After making any code changes, you must run both the local unit tests (`PYTHONPATH=src python3 -m pytest`) and the full Docker-based integration tests.
+- **Astral Toolchain**: Use `uv` to install dependencies and run commands, `ruff` for linting and formatting, and `ty` for type checking.
+- **Run All Tests After Changes**: After making any code changes, you must run the local checks (`uv run pytest`, `uv run --group lint ruff check .`, `uv run --group lint ruff format --check .`, `uv run --group type ty check`) and the full Docker-based integration tests.
 
 ### Integration Tests
 
@@ -72,7 +72,7 @@ Knocker is a dynamic IP whitelisting service that integrates with reverse proxie
 ## Workflow
 
 - **Create Git Commits**: All work should be committed to Git.
-- **Run All Tests After Changes**: After making any code changes, you must run both the local unit tests (`PYTHONPATH=src python3 -m pytest`) and the Docker-based integration tests using the standard `dev/` compose files plus the scripts under `dev/`.
+- **Run All Tests After Changes**: After making any code changes, you must run the local checks (`uv run pytest`, `uv run --group lint ruff check .`, `uv run --group lint ruff format --check .`, `uv run --group type ty check`) and the Docker-based integration tests using the standard `dev/` compose files plus the scripts under `dev/`.
 
 ## Repository Information
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,8 @@ on:
     branches: [ "main" ]
     paths:
       - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - 'src/**'
       - '.github/workflows/docker-publish.yml'
     # Publish semver tags as releases.
@@ -18,6 +20,8 @@ on:
     branches: [ "main" ]
     paths:
       - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - 'src/**'
   workflow_dispatch:
 env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,18 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
+      - pyproject.toml
+      - uv.lock
+      - Dockerfile
       - src/**
       - dev/**
       - tests/**
   push:
     branches: [ "main" ]
     paths:
+      - pyproject.toml
+      - uv.lock
+      - Dockerfile
       - src/**
       - dev/**
       - tests/**
@@ -26,13 +32,27 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version-file: 'pyproject.toml'
 
-    - name: Install dependencies
-      run: pip install -r src/requirements.txt
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: true
+
+    - name: Sync project dependencies
+      run: uv sync --locked --all-groups
+
+    - name: Run Ruff lint checks
+      run: uv run --group lint ruff check .
+
+    - name: Run Ruff format checks
+      run: uv run --group lint ruff format --check .
+
+    - name: Run ty checks
+      run: uv run --group type ty check
 
     - name: Run unit tests
-      run: PYTHONPATH=src python3 -m pytest
+      run: uv run pytest
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ knocker.yaml
 whitelist.json
 test_whitelist.json
 *.lock
+!uv.lock
 
 # Runtime-generated OpenAPI schema
 openapi.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,14 @@ This file provides guidance to agents when working with code in this repository.
 
 - **Configuration is Mandatory**: The application will not start without the `KNOCKER_CONFIG_PATH` environment variable pointing to a valid `knocker.yaml` file. See [`knocker.example.yaml`](knocker.example.yaml:1) for the required structure.
 - **IP Spoofing Risk**: The service's security depends on the `trusted_proxies` list in `knocker.yaml`. If this is misconfigured, clients can easily spoof their IP address via the `X-Forwarded-For` header.
-- **Testing Requires `PYTHONPATH`**: Unit tests must be run with `PYTHONPATH=src python3 -m pytest`. Without this, imports will fail.
+- **Astral Toolchain**: This project uses `uv` for environment and dependency management, `ruff` for linting and formatting, and `ty` for type checking.
 - **Whitelist Persistence**: The IP whitelist is stored in a simple JSON file (`/data/whitelist.json` inside the container), not a database. The path is configured in `knocker.yaml`.
 - **API Key Permissions**: API keys have two important properties: `allow_remote_whitelist` (boolean) and `max_ttl` (integer). A key with `allow_remote_whitelist: false` can only whitelist its own source IP. `max_ttl` defines the maximum duration in seconds an IP can be whitelisted for with that key.
 - **Development/Test Stacks**: Use `dev/docker-compose.yml` for the firewalld/local stack and `dev/docker-compose.ci.yml` for the CI/unprivileged stack. Both are test stacks and expose Caddy on host ports `18080` and `18443`.
 
 ## Workflow
 
-- **Run All Tests After Changes**: After making any code changes, you must run both the local unit tests (`PYTHONPATH=src python3 -m pytest`) and the Docker-based integration tests using the standard `dev/` compose files plus the scripts under `dev/`.
+- **Run All Tests After Changes**: After making any code changes, you must run the local checks (`uv run pytest`, `uv run --group lint ruff check .`, `uv run --group lint ruff format --check .`, and `uv run --group type ty check`) and the Docker-based integration tests using the standard `dev/` compose files plus the scripts under `dev/`.
 - **Create Git Commits**: All work should be committed to Git.
 
 - github repo: FarisZR/knocker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,24 @@ Knocker is a self-hosted single-packet authorization (SPA) gateway for homelabs.
 ### Testing
 
 ```bash
-# Run unit tests (must set PYTHONPATH)
-PYTHONPATH=src python3 -m pytest
+# Sync the local environment
+uv sync --all-groups
+
+# Run unit tests
+uv run pytest
 
 # Run specific test file
-PYTHONPATH=src python3 -m pytest tests/test_core.py
+uv run pytest tests/test_core.py
 
 # Run with verbose output
-PYTHONPATH=src python3 -m pytest -v
+uv run pytest -v
+
+# Run lint and format checks
+uv run --group lint ruff check .
+uv run --group lint ruff format --check .
+
+# Run type checks
+uv run --group type ty check
 
 # Run integration tests (requires Docker)
 cd dev && ./local_integration_tests.sh
@@ -42,7 +52,7 @@ docker compose -f dev/docker-compose.yml down
 # The dev test stack exposes Caddy on localhost:18080 and localhost:18443
 
 # Install dependencies locally
-pip install -r src/requirements.txt
+uv sync --all-groups
 ```
 
 ### Running Locally (without Docker)
@@ -50,7 +60,7 @@ pip install -r src/requirements.txt
 ```bash
 # Set config path and run with uvicorn
 export KNOCKER_CONFIG_PATH=knocker.yaml
-cd src && uvicorn main:app --reload --host 0.0.0.0 --port 8000
+uv run uvicorn src.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 ### Building Docker Image
@@ -129,7 +139,7 @@ See [docs/FIREWALLD_INTEGRATION.md](docs/FIREWALLD_INTEGRATION.md) for detailed 
 
 ### Unit Tests
 
-- **MUST** set `PYTHONPATH=src` or imports will fail
+- Run tests from the repository root with `uv run pytest`
 - Tests use fixtures in `conftest.py` (if present) and mock external dependencies
 - Security tests validate IP spoofing prevention, CIDR range limits, and API key permissions
 
@@ -184,12 +194,13 @@ Keys are IPs/CIDRs, values are Unix timestamps for expiration.
 ## Workflow
 
 After making changes:
-1. Run unit tests: `PYTHONPATH=src python3 -m pytest`
+1. Run unit tests: `uv run pytest`
 2. Build and test with Docker: `cd dev && docker compose up --build -d`
 3. Run integration tests: `cd dev && ./local_integration_tests.sh`
 4. If modifying FirewallD code, run: `cd dev && ./firewalld_integration_test.sh`
-5. Update relevant documentation in [docs/](docs/)
-6. Commit with descriptive message
+5. Run tooling checks: `uv run --group lint ruff check .`, `uv run --group lint ruff format --check .`, and `uv run --group type ty check`
+6. Update relevant documentation in [docs/](docs/)
+7. Commit with descriptive message
 
 ## Known Issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ uv sync --all-groups
 
 ```bash
 # Set config path and run with uvicorn
-export KNOCKER_CONFIG_PATH=knocker.yaml
-uv run uvicorn src.main:app --reload --host 0.0.0.0 --port 8000
+export KNOCKER_CONFIG_PATH=$(pwd)/knocker.yaml
+uv run uvicorn src.main:app --reload --host 0.0.0.0 --port 8000 --no-proxy-headers
 ```
 
 ### Building Docker Image
@@ -175,10 +175,10 @@ The [dev/firewalld_integration_test.sh](dev/firewalld_integration_test.sh):
 
 ### Uvicorn Configuration
 
-The application runs with `--forwarded-allow-ips="*"` because:
-- Only reverse proxy (Caddy) can reach the container on Docker network
-- Knocker validates trusted proxies internally via `trusted_proxies` list
-- This allows proper X-Forwarded-For header processing
+The production container runs Uvicorn with `--no-proxy-headers`.
+- Knocker resolves the direct peer from `request.client.host`
+- `src.core.resolve_client_ip()` only consults `X-Forwarded-For` when that direct peer is listed in `server.trusted_proxies`
+- Invalid or malformed forwarded chains from trusted proxies are rejected instead of falling back to a guessed client IP
 
 ### Whitelist File Format
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 # Use a specific, stable version of Python for reproducibility
 FROM python:3.13-slim
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /uvx /bin/
+
 # Set the working directory in the container
 WORKDIR /app
+
+ENV UV_LINK_MODE=copy
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_PYTHON_DOWNLOADS=0
+ENV KNOCKER_CONFIG_PATH=/app/knocker.yaml
 
 # Create a non-root user to run the application for better security
 # NOTE: When firewalld integration is enabled, the container must run as root
@@ -10,22 +17,25 @@ WORKDIR /app
 RUN groupadd --gid 1001 appuser && \
     useradd --create-home --uid 1001 --gid 1001 appuser
 
-# Copy requirements and install dependencies system-wide
-COPY src/requirements.txt .
+# Install system packages, then sync runtime dependencies with uv.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl firewalld && \
-    pip install --no-cache-dir -r requirements.txt && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+COPY pyproject.toml uv.lock ./
+RUN uv sync --locked --no-dev
+
 # Copy the rest of the application code
-COPY src/ .
+COPY src ./src
 
 # Create and change ownership of the data directory to the appuser
 RUN mkdir -p /data && chown appuser:appuser /data
 
 # Switch to the non-root user for running the application
 USER appuser
+
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Expose the port the app runs on
 EXPOSE 8000
@@ -34,4 +44,4 @@ EXPOSE 8000
 # Define the command to run the application.
 # Keep Uvicorn from rewriting the direct peer from forwarded headers; Knocker
 # performs its own trusted-proxy validation using server.trusted_proxies.
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--no-proxy-headers"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-proxy-headers"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Expose the port the app runs on
 EXPOSE 8000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl --fail --silent http://localhost:8000/health > /dev/null || exit 1
+
 
 # Define the command to run the application.
 # Keep Uvicorn from rewriting the direct peer from forwarded headers; Knocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Use a specific, stable version of Python for reproducibility
 FROM python:3.13-slim
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /uvx /bin/
+# Install uv from the official installer so multi-arch builds work.
+ADD https://astral.sh/uv/0.11.2/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+
+ENV PATH="/root/.local/bin:$PATH"
 
 # Set the working directory in the container
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 # Use a specific, stable version of Python for reproducibility
 FROM python:3.13-slim
 
-# Install uv from the official installer so multi-arch builds work.
-ADD https://astral.sh/uv/0.11.2/install.sh /uv-installer.sh
-RUN sh /uv-installer.sh && rm /uv-installer.sh
-
-ENV PATH="/root/.local/bin:$PATH"
-
 # Set the working directory in the container
 WORKDIR /app
 
@@ -15,17 +9,23 @@ ENV UV_COMPILE_BYTECODE=1
 ENV UV_PYTHON_DOWNLOADS=0
 ENV KNOCKER_CONFIG_PATH=/app/knocker.yaml
 
+# Install system packages before running the uv installer, which requires curl.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl firewalld && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install uv from the official installer so multi-arch builds work.
+ADD https://astral.sh/uv/0.11.2/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+
+ENV PATH="/root/.local/bin:$PATH"
+
 # Create a non-root user to run the application for better security
 # NOTE: When firewalld integration is enabled, the container must run as root
 # to access the system dbus. This is configured in docker-compose.yml.
 RUN groupadd --gid 1001 appuser && \
     useradd --create-home --uid 1001 --gid 1001 appuser
-
-# Install system packages, then sync runtime dependencies with uv.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl firewalld && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --locked --no-dev

--- a/README.md
+++ b/README.md
@@ -256,17 +256,33 @@ Caddy already forwards the relevant `X-Forwarded-*` request headers to Knocker s
 ## Tests
 The project includes a full test suite
 
+### Tooling
+
+This project uses Astral's Python toolchain:
+
+- `uv` for dependency management, environments, and command execution
+- `ruff` for linting and formatting
+- `ty` for type checking
+
 ### Unit tests
 To run the tests locally:
 
-1.  **Install Dependencies**:
+1.  **Install uv**:
     ```bash
-    pip install -r src/requirements.txt
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
 
-2.  **Run Pytest**:
+2.  **Sync the project environment**:
     ```bash
-    PYTHONPATH=src python3 -m pytest
+    uv sync --all-groups
+    ```
+
+3.  **Run the checks**:
+    ```bash
+    uv run pytest
+    uv run --group lint ruff check .
+    uv run --group lint ruff format --check .
+    uv run --group type ty check
     ```
 
 ### Integration Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,10 @@ services:
     restart: unless-stopped
     networks:
       - caddy_net
+    environment:
+      - KNOCKER_CONFIG_PATH=/app/knocker.yaml
     volumes:
-      - ./knocker.yaml:/knocker.yaml
+      - ./knocker.yaml:/app/knocker.yaml:ro
       - ./knocker_data:/data
       # REQUIRED OPTIONS for firewalld integration
       # - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -52,4 +52,4 @@ This document outlines the key architectural and design decisions made during th
 
 ### 7. Import Compatibility
 
-The FastAPI entrypoint (`main.py`) now supports both relative (`from . import core`) and absolute (`import core`) imports. This guards against import errors when the service runs as a package (for example `uvicorn src.main:app`) and when tests import the module directly via `PYTHONPATH=src`. When running inside Docker the runtime now avoids trying to import `src.core` explicitly, ensuring the health checks succeed regardless of the deployment layout.
+The FastAPI entrypoint (`main.py`) now supports both relative (`from . import core`) and absolute (`import core`) imports. This guards against import errors when the service runs as a package (for example `uvicorn src.main:app`) and when local tooling executes the test suite from the repository root via `uv run pytest`. When running inside Docker the runtime now avoids trying to import `src.core` explicitly, ensuring the health checks succeed regardless of the deployment layout.

--- a/docs/FIREWALLD_INTEGRATION.md
+++ b/docs/FIREWALLD_INTEGRATION.md
@@ -324,7 +324,7 @@ The `/health` endpoint can be used to verify the service is running, but it does
 Run the comprehensive firewalld test suite:
 
 ```bash
-PYTHONPATH=src python3 -m pytest tests/test_firewalld.py -v
+uv run pytest tests/test_firewalld.py -v
 ```
 
 ### Integration Tests

--- a/docs/Project-OVERVIEW.md
+++ b/docs/Project-OVERVIEW.md
@@ -23,7 +23,7 @@ This is ideal for homelab environments where you want to expose services to the 
 This project uses GitHub Actions for continuous integration and deployment.
 
 *   **CI (`tests.yml`)**: On every pull request to `main`, this workflow runs the full Python test suite and then performs a live integration test with Docker Compose to ensure the Caddy and Knocker services work together correctly.
-*   **Docker Publish (`docker-publish.yml`)**: Builds and publishes multi-arch Docker images to GitHub Container Registry (ghcr.io)
+*   **Docker Publish (`docker-publish.yml`)**: Builds and publishes multi-arch Docker images to GitHub Container Registry (ghcr.io). The Dockerfile installs `uv` with Astral's installer script instead of `COPY --from=ghcr.io/astral-sh/uv`, because the installer path is more reliable across the Buildx target platforms used by this project.
     - On push to `main` → `ghcr.io/fariszr/knocker:main` (rolling development)
     - On version tags (v1.2.3) → Multiple tags including `:latest`, `:v1.2.3`, `:1.2.3`, `:1.2`, `:1` (stable releases)
 *   **Release Workflow (`release.yml`)**: On version tags, automatically creates GitHub releases with changelogs and installation instructions

--- a/docs/Project-OVERVIEW.md
+++ b/docs/Project-OVERVIEW.md
@@ -225,12 +225,12 @@ To run the tests locally:
 
 1.  **Install Dependencies**:
     ```bash
-    pip install -r src/requirements.txt
+    uv sync --all-groups
     ```
 
 2.  **Run Pytest**:
     ```bash
-    PYTHONPATH=src python3 -m pytest
+    uv run pytest
     ```
 
 ### Integration Tests

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -142,7 +142,7 @@ The project includes comprehensive security tests in `tests/test_security_fixes.
 
 Run security tests with:
 ```bash
-PYTHONPATH=src python3 -m pytest tests/test_security_fixes.py -v
+uv run pytest tests/test_security_fixes.py -v
 ```
 
 ## Reporting Security Issues

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -97,7 +97,7 @@ cors:
 ### 1. Network Configuration
 
 - **Always configure trusted_proxies**: Only include the actual reverse proxy IPs/networks
-- **Leave proxy-header resolution to Knocker**: Do not enable Uvicorn proxy-header rewriting in front of `server.trusted_proxies`
+- **Leave proxy-header resolution to Knocker**: Run Uvicorn with `--no-proxy-headers` so Knocker can resolve the direct peer from `request.client.host` before consulting `server.trusted_proxies`
 - **Reject malformed forwarded chains**: If a trusted proxy sends an invalid `X-Forwarded-For` chain, Knocker now treats the client IP as unresolved instead of falling back to the proxy IP
 - **Use Docker networks**: Isolate knocker service on a private Docker network
 - **Firewall rules**: Restrict direct access to the knocker service port

--- a/docs/SECURITY_AUDIT_SUMMARY.md
+++ b/docs/SECURITY_AUDIT_SUMMARY.md
@@ -115,10 +115,10 @@ All changes maintain full backward compatibility:
 Run the complete security test suite:
 ```bash
 # Run all tests (should show 5 expected failures in vulnerability tests)
-PYTHONPATH=src python3 -m pytest -v
+uv run pytest -v
 
 # Run only security fix validation tests (should all pass)
-PYTHONPATH=src python3 -m pytest tests/test_security_fixes.py -v
+uv run pytest tests/test_security_fixes.py -v
 ```
 
 ## Files Modified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "knocker"
+version = "0.0.0"
+description = "Self-hosted single-packet authorization gateway for homelabs"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "fastapi>=0.121.0",
+    "pyyaml>=6.0.3",
+    "uvicorn>=0.38.0",
+]
+
+[dependency-groups]
+dev = [
+    "httpx>=0.28.1",
+    "pytest>=8.4.2",
+]
+lint = [
+    "ruff>=0.14.3",
+]
+type = [
+    "ty>=0.0.1a19",
+]
+
+[tool.uv]
+package = false
+
+[tool.ruff]
+target-version = "py313"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E712"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["E722"]
+"tests/test_main_firewalld_integration.py" = ["F401"]
+
+[tool.ty.environment]
+python-version = "3.13"
+root = [".", "./src"]
+
+[tool.ty.src]
+include = ["src", "tests"]
+
+[tool.ty.rules]
+all = "warn"
+
+[tool.ty.terminal]
+error-on-warning = false
+output-format = "concise"

--- a/src/config.py
+++ b/src/config.py
@@ -46,11 +46,11 @@ def load_config() -> Dict[str, Any]:
 
     # Security: Validate path to prevent directory traversal and ensure it's absolute
     try:
-        resolved_path = os.path.realpath(path)
         # Ensure the path doesn't contain suspicious patterns
-        if ".." in path or not os.path.isabs(resolved_path):
+        if ".." in path or not os.path.isabs(path):
             logging.critical(f"Invalid configuration path: {path}")
             sys.exit(1)
+        resolved_path = os.path.realpath(path)
     except (OSError, ValueError) as e:
         logging.critical(f"Error validating configuration path {path}: {e}")
         sys.exit(1)

--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,7 @@ try:
 except ImportError:  # pragma: no cover - fallback for direct module execution
     import core
 
+
 def setup_logging(settings: Dict[str, Any]):
     """
     Configures logging for the application.
@@ -24,13 +25,14 @@ def setup_logging(settings: Dict[str, Any]):
         level=log_level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         stream=sys.stdout,
-        force=True
+        force=True,
     )
 
     # Ensure the root logger and common framework loggers follow the configured level.
     logging.getLogger().setLevel(log_level)
     for logger_name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
         logging.getLogger(logger_name).setLevel(log_level)
+
 
 def load_config() -> Dict[str, Any]:
     """
@@ -46,7 +48,7 @@ def load_config() -> Dict[str, Any]:
     try:
         resolved_path = os.path.realpath(path)
         # Ensure the path doesn't contain suspicious patterns
-        if '..' in path or not os.path.isabs(resolved_path):
+        if ".." in path or not os.path.isabs(resolved_path):
             logging.critical(f"Invalid configuration path: {path}")
             sys.exit(1)
     except (OSError, ValueError) as e:
@@ -54,9 +56,9 @@ def load_config() -> Dict[str, Any]:
         sys.exit(1)
 
     try:
-        with open(resolved_path, 'r') as f:
+        with open(resolved_path, "r") as f:
             config = yaml.safe_load(f) or {}
-            
+
         # Validate configuration structure
         if not isinstance(config, dict):
             logging.critical("Configuration file must contain a valid YAML dictionary")
@@ -67,7 +69,7 @@ def load_config() -> Dict[str, Any]:
         except ValueError as exc:
             logging.critical(f"Invalid configuration: {exc}")
             sys.exit(1)
-            
+
         return config
     except FileNotFoundError:
         logging.critical(f"Configuration file not found at {resolved_path}")

--- a/src/core.py
+++ b/src/core.py
@@ -67,9 +67,7 @@ def validate_whitelist_storage_path(
         for root in allowed_roots
     ):
         allowed = ", ".join(allowed_roots)
-        raise ValueError(
-            f"whitelist.storage_path must stay within one of these roots: {allowed}"
-        )
+        raise ValueError(f"whitelist.storage_path must stay within one of these roots: {allowed}")
 
     return Path(resolved_path)
 
@@ -79,7 +77,9 @@ def get_whitelist_storage_path(settings: Dict[str, Any]) -> Path:
     if not isinstance(whitelist_settings, dict):
         raise ValueError("whitelist configuration must be a mapping")
 
-    storage_path = validate_whitelist_storage_path(whitelist_settings.get("storage_path", "whitelist.json"))
+    storage_path = validate_whitelist_storage_path(
+        whitelist_settings.get("storage_path", "whitelist.json")
+    )
     whitelist_settings["storage_path"] = str(storage_path)
     return storage_path
 
@@ -129,7 +129,9 @@ def _canonical_network(value: str) -> Tuple[str, IPNetwork]:
     return str(network), network
 
 
-def _parse_entry_list(entries: Iterable[str], label: str) -> Tuple[Tuple[IPAddress, ...], Tuple[IPNetwork, ...]]:
+def _parse_entry_list(
+    entries: Iterable[str], label: str
+) -> Tuple[Tuple[IPAddress, ...], Tuple[IPNetwork, ...]]:
     exact: list[IPAddress] = []
     networks: list[IPNetwork] = []
     for entry in entries:
@@ -204,14 +206,22 @@ class DynamicWhitelistIndex:
             expiry = self.exact_v4.get(address)
             if expiry and expiry > now:
                 return True
-            return any(expiry_time > now and address in network for network, expiry_time in self.networks_v4.items())
+            return any(
+                expiry_time > now and address in network
+                for network, expiry_time in self.networks_v4.items()
+            )
 
         expiry = self.exact_v6.get(address)
         if expiry and expiry > now:
             return True
-        return any(expiry_time > now and address in network for network, expiry_time in self.networks_v6.items())
+        return any(
+            expiry_time > now and address in network
+            for network, expiry_time in self.networks_v6.items()
+        )
 
-    def to_serialized(self, now: Optional[int] = None, include_expired: bool = True) -> Dict[str, int]:
+    def to_serialized(
+        self, now: Optional[int] = None, include_expired: bool = True
+    ) -> Dict[str, int]:
         serialized: Dict[str, int] = {}
         cutoff = int(time.time()) if now is None else now
 
@@ -330,9 +340,13 @@ class WhitelistStore:
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
         if self.storage_path.exists():
             if not os.access(self.storage_path, os.R_OK | os.W_OK):
-                raise ValueError(f"Whitelist storage path is not readable and writable: {self.storage_path}")
+                raise ValueError(
+                    f"Whitelist storage path is not readable and writable: {self.storage_path}"
+                )
         elif not os.access(self.storage_path.parent, os.R_OK | os.W_OK | os.X_OK):
-            raise ValueError(f"Whitelist storage directory is not accessible: {self.storage_path.parent}")
+            raise ValueError(
+                f"Whitelist storage directory is not accessible: {self.storage_path.parent}"
+            )
         self.reload_from_disk()
 
     def _storage_version_token(self) -> Optional[Tuple[int, int, int]]:
@@ -342,12 +356,16 @@ class WhitelistStore:
             return None
         return (stat_result.st_mtime_ns, stat_result.st_size, stat_result.st_ino)
 
-    def _reload_from_disk_locked(self, storage_version: Optional[Tuple[int, int, int]] = None) -> None:
+    def _reload_from_disk_locked(
+        self, storage_version: Optional[Tuple[int, int, int]] = None
+    ) -> None:
         raw = _read_whitelist_file(self.storage_path)
         normalized, changed = _normalize_serialized_whitelist(raw, drop_expired=True)
         self._index = DynamicWhitelistIndex.from_serialized(normalized)
         self._pending_compaction = changed
-        self._storage_version = storage_version if storage_version is not None else self._storage_version_token()
+        self._storage_version = (
+            storage_version if storage_version is not None else self._storage_version_token()
+        )
 
     def reload_from_disk(self) -> None:
         with self._lock:
@@ -366,13 +384,17 @@ class WhitelistStore:
 
         now = int(time.time())
         if expiry_time <= now:
-            raise ValueError(f"Expiry time {expiry_time} is not in the future (current time: {now})")
+            raise ValueError(
+                f"Expiry time {expiry_time} is not in the future (current time: {now})"
+            )
 
         canonical, _ = _canonical_network(ip_or_cidr)
         with self._lock:
             with _interprocess_whitelist_lock(self.storage_path):
                 persisted = _read_whitelist_file(self.storage_path)
-                normalized, _ = _normalize_serialized_whitelist(persisted, drop_expired=True, now=now)
+                normalized, _ = _normalize_serialized_whitelist(
+                    persisted, drop_expired=True, now=now
+                )
                 normalized[canonical] = expiry_time
                 normalized = _limit_whitelist_entries(normalized, self.max_entries)
                 _write_whitelist_file(self.storage_path, normalized)
@@ -387,7 +409,9 @@ class WhitelistStore:
         with self._lock:
             with _interprocess_whitelist_lock(self.storage_path):
                 _write_whitelist_file(self.storage_path, normalized)
-                active, changed = _normalize_serialized_whitelist(normalized, drop_expired=True, now=now)
+                active, changed = _normalize_serialized_whitelist(
+                    normalized, drop_expired=True, now=now
+                )
                 self._index = DynamicWhitelistIndex.from_serialized(active)
                 self._pending_compaction = changed
                 self._storage_version = self._storage_version_token()
@@ -397,13 +421,17 @@ class WhitelistStore:
         cutoff = int(time.time()) if now is None else now
         with self._lock:
             before = self._index.to_serialized(include_expired=True)
-            after = _limit_whitelist_entries(self._index.to_serialized(now=cutoff, include_expired=False), self.max_entries)
+            after = _limit_whitelist_entries(
+                self._index.to_serialized(now=cutoff, include_expired=False), self.max_entries
+            )
             if not self._pending_compaction and before == after:
                 return False
 
             with _interprocess_whitelist_lock(self.storage_path):
                 persisted = _read_whitelist_file(self.storage_path)
-                active, changed = _normalize_serialized_whitelist(persisted, drop_expired=True, now=cutoff)
+                active, changed = _normalize_serialized_whitelist(
+                    persisted, drop_expired=True, now=cutoff
+                )
                 compacted = _limit_whitelist_entries(active, self.max_entries)
                 wrote = changed or compacted != persisted
                 if wrote:
@@ -583,7 +611,9 @@ def is_path_excluded(path: str, settings: Dict[str, Any], host: Optional[str] = 
     return path_exclusions.matches(host, path)
 
 
-def is_trusted_proxy(client_ip: str, trusted_proxies: Union[Sequence[str], ParsedNetworkSet]) -> bool:
+def is_trusted_proxy(
+    client_ip: str, trusted_proxies: Union[Sequence[str], ParsedNetworkSet]
+) -> bool:
     if not client_ip:
         return False
 
@@ -764,7 +794,9 @@ class SlidingWindowRateLimiter:
     window_seconds: int
     successful_requests: int
     failed_requests: int
-    _events: Dict[Tuple[str, str], Deque[Tuple[int, int]]] = field(default_factory=lambda: defaultdict(deque))
+    _events: Dict[Tuple[str, str], Deque[Tuple[int, int]]] = field(
+        default_factory=lambda: defaultdict(deque)
+    )
     _lock: threading.RLock = field(default_factory=threading.RLock)
     _token_counter: int = field(default=0, init=False)
     _last_global_prune: int = field(default=0, init=False)
@@ -804,7 +836,9 @@ class SlidingWindowRateLimiter:
 
         self._last_global_prune = now
 
-    def reserve(self, actor: str, outcome: str, now: Optional[int] = None) -> Optional[Tuple[int, int]]:
+    def reserve(
+        self, actor: str, outcome: str, now: Optional[int] = None
+    ) -> Optional[Tuple[int, int]]:
         limit = self.successful_requests if outcome == "success" else self.failed_requests
         timestamp = int(time.time()) if now is None else now
         if limit == 0:
@@ -933,7 +967,9 @@ def _validate_firewalld_config(settings: Dict[str, Any]) -> None:
         port = port_config.get("port")
         protocol = port_config.get("protocol", "tcp")
         if not isinstance(port, int) or not (1 <= port <= 65535):
-            raise ValueError(f"firewalld.monitored_ports[{index}].port must be an integer between 1 and 65535")
+            raise ValueError(
+                f"firewalld.monitored_ports[{index}].port must be an integer between 1 and 65535"
+            )
         if protocol not in {"tcp", "udp"}:
             raise ValueError(f"firewalld.monitored_ports[{index}].protocol must be 'tcp' or 'udp'")
 
@@ -964,7 +1000,9 @@ def ensure_runtime_state(settings: Dict[str, Any]) -> RuntimeState:
         security_settings = settings.get("security", {}) or {}
         whitelist_settings = settings.get("whitelist", {}) or {}
 
-        trusted_proxies = ParsedNetworkSet.from_entries(server_settings.get("trusted_proxies", []) or [], "trusted_proxies")
+        trusted_proxies = ParsedNetworkSet.from_entries(
+            server_settings.get("trusted_proxies", []) or [], "trusted_proxies"
+        )
         always_allowed = ParsedNetworkSet.from_entries(
             security_settings.get("always_allowed_ips", []) or [],
             "always_allowed_ips",
@@ -1050,7 +1088,9 @@ def is_ip_whitelisted(ip: str, whitelist: Dict[str, int], settings: Dict[str, An
         return False
 
     runtime_state = settings.get(_RUNTIME_STATE_KEY)
-    if isinstance(runtime_state, RuntimeState) and runtime_state.always_allowed_ips.contains(address):
+    if isinstance(runtime_state, RuntimeState) and runtime_state.always_allowed_ips.contains(
+        address
+    ):
         return True
 
     if not isinstance(runtime_state, RuntimeState):
@@ -1088,7 +1128,9 @@ def can_record_knock_attempt(settings: Dict[str, Any], actor: str, outcome: str)
     return runtime_state.rate_limiter.can_allow(actor, outcome, int(time.time()))
 
 
-def add_ip_to_whitelist_with_firewalld(ip_or_cidr: str, expiry_time: int, settings: Dict[str, Any]) -> bool:
+def add_ip_to_whitelist_with_firewalld(
+    ip_or_cidr: str, expiry_time: int, settings: Dict[str, Any]
+) -> bool:
     try:
         from . import firewalld
     except ImportError:

--- a/src/firewalld.py
+++ b/src/firewalld.py
@@ -24,18 +24,19 @@ else:
 @dataclass
 class FirewalldRule:
     """Represents a firewalld rule for an IP/port combination."""
+
     ip_address: str
     port: int
     protocol: str
     expiry_time: int
-    
+
     def __str__(self):
         return f"{self.ip_address}:{self.port}/{self.protocol} (expires: {self.expiry_time})"
 
 
 class FirewalldIntegration:
     """Handles all firewalld operations for Knocker."""
-    
+
     def __init__(self, settings: Dict[str, Any]):
         """Initialize firewalld integration with configuration settings."""
         self.settings = settings
@@ -47,37 +48,43 @@ class FirewalldIntegration:
         self.zone_target = self.firewalld_config.get("zone_target", None)
         self.monitored_ports = self.firewalld_config.get("monitored_ports", [])
         self.monitored_ips = self.firewalld_config.get("monitored_ips", [])
-        
+
         self.logger = logging.getLogger(__name__)
 
         if self.enabled:
-            if not isinstance(self.zone_name, str) or not core._ZONE_NAME_RE.fullmatch(self.zone_name):
+            if not isinstance(self.zone_name, str) or not core._ZONE_NAME_RE.fullmatch(
+                self.zone_name
+            ):
                 raise ValueError(
                     "Invalid zone_name. Use only letters, numbers, dots, underscores, colons, and hyphens"
                 )
 
             # Validate monitored IPs have proper CIDR notation
             self._validate_monitored_ips()
-            
+
             # Validate default action
             if self.default_action not in ["drop", "reject"]:
-                raise ValueError(f"Invalid default_action '{self.default_action}'. Must be 'drop' or 'reject'")
-            
+                raise ValueError(
+                    f"Invalid default_action '{self.default_action}'. Must be 'drop' or 'reject'"
+                )
+
             # Validate zone_target if specified
             if self.zone_target is not None:
                 valid_targets = ["default", "ACCEPT", "REJECT", "DROP"]
                 if self.zone_target not in valid_targets:
-                    raise ValueError(f"Invalid zone_target '{self.zone_target}'. Must be one of: {', '.join(valid_targets)}")
-        
+                    raise ValueError(
+                        f"Invalid zone_target '{self.zone_target}'. Must be one of: {', '.join(valid_targets)}"
+                    )
+
     def _validate_monitored_ips(self):
         """Validate that all monitored IPs have proper CIDR notation."""
         for ip_str in self.monitored_ips:
             try:
                 if not isinstance(ip_str, str):
                     raise ValueError("Monitored IP entries must be strings")
-                if '/' not in ip_str:
+                if "/" not in ip_str:
                     raise ValueError("Entries must include an explicit network mask")
-                network = ipaddress.ip_network(ip_str, strict=False)
+                ipaddress.ip_network(ip_str, strict=False)
                 # Check if it's a single host without explicit netmask
             except ValueError as e:
                 self.logger.error(f"Invalid monitored IP '{ip_str}': {e}")
@@ -86,11 +93,11 @@ class FirewalldIntegration:
     def is_enabled(self) -> bool:
         """Check if firewalld integration is enabled."""
         return self.enabled
-        
+
     def _run_firewall_cmd(self, args: List[str], check: bool = True) -> Tuple[bool, str, str]:
         """
         Run firewall-cmd with given arguments.
-        
+
         Returns:
             Tuple of (success, stdout, stderr)
         """
@@ -110,13 +117,7 @@ class FirewalldIntegration:
             pass
 
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=check
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=check)
             return True, result.stdout.strip(), result.stderr.strip()
         except subprocess.CalledProcessError as e:
             self.logger.error(f"firewall-cmd failed: {e.stderr}")
@@ -127,56 +128,56 @@ class FirewalldIntegration:
         except Exception as e:
             self.logger.error(f"Unexpected error running firewall-cmd: {e}")
             return False, "", str(e)
-    
+
     def _build_rich_rule(self, ip_address: str, port: int, protocol: str) -> Optional[str]:
         """
         Build a properly formatted rich rule for firewalld.
-        
+
         Args:
             ip_address: IP address or CIDR to whitelist
             port: Port number
             protocol: Protocol (tcp/udp)
-            
+
         Returns:
             Formatted rich rule string, or None if validation fails
         """
         try:
             # Validate and normalize the IP address/CIDR
             network = ipaddress.ip_network(ip_address, strict=False)
-            
+
             # Determine IP family (ipv4 or ipv6)
             family = "ipv4" if network.version == 4 else "ipv6"
-            
+
             # Format source address - use with_prefixlen for CIDR, just the address for single hosts
             if network.num_addresses == 1:
                 source_addr = str(network.network_address)
             else:
                 source_addr = str(network)
-            
+
             # Validate port
             if not isinstance(port, int) or port < 1 or port > 65535:
                 self.logger.error(f"Invalid port number: {port}")
                 return None
-            
+
             # Validate protocol
             if not isinstance(protocol, str) or protocol not in ["tcp", "udp"]:
                 self.logger.error(f"Invalid protocol: {protocol}")
                 return None
-            
+
             # Build the rich rule with high priority (low number = 1000) to override DROP rules
             rich_rule = f'rule family="{family}" source address="{source_addr}" port protocol="{protocol}" port="{port}" accept priority="1000"'
             return rich_rule
-            
+
         except (ValueError, ipaddress.AddressValueError) as e:
             self.logger.error(f"Invalid IP address or CIDR '{ip_address}': {e}")
             return None
-            
+
     def is_firewalld_available(self) -> bool:
         """Check if firewalld is available and running."""
         success, stdout, stderr = self._run_firewall_cmd(["--state"], check=False)
         if success and "running" in stdout:
             return True
-        
+
         self.logger.warning(f"Firewalld not available: {stderr}")
         return False
 
@@ -213,7 +214,7 @@ class FirewalldIntegration:
             version_str = ver_text
 
         try:
-            parts = version_str.split('.')
+            parts = version_str.split(".")
             major = int(parts[0]) if len(parts) > 0 and parts[0].isdigit() else 0
             minor = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
             patch = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
@@ -226,94 +227,104 @@ class FirewalldIntegration:
         except Exception as e:
             self.logger.error(f"Unable to parse firewalld version from output '{stdout}': {e}")
             return False
-        
+
     def setup_knocker_zone(self) -> bool:
         """
         Create and configure the knocker firewalld zone.
-        
+
         Returns:
             True if successful, False otherwise
         """
         if not self.is_enabled():
             return True
-            
+
         if not self.is_firewalld_available():
             return False
-            
+
         try:
             # Check if zone already exists
             success, stdout, _ = self._run_firewall_cmd(["--get-zones"], check=False)
             zone_exists = success and self.zone_name in stdout
             if not zone_exists:
                 # Create the zone
-                success, stdout, stderr = self._run_firewall_cmd([
-                    "--permanent", f"--new-zone={self.zone_name}"
-                ])
+                success, stdout, stderr = self._run_firewall_cmd(
+                    ["--permanent", f"--new-zone={self.zone_name}"]
+                )
                 if not success:
                     self.logger.error(f"Failed to create zone {self.zone_name}: {stderr}")
                     return False
-                    
+
                 self.logger.info(f"Created firewalld zone: {self.zone_name}")
-            
+
             # Set zone priority (negative numbers have higher priority)
-            success, _, stderr = self._run_firewall_cmd([
-                "--permanent", f"--zone={self.zone_name}", f"--set-priority={self.zone_priority}"
-            ])
+            success, _, stderr = self._run_firewall_cmd(
+                ["--permanent", f"--zone={self.zone_name}", f"--set-priority={self.zone_priority}"]
+            )
             if not success:
                 self.logger.warning(f"Failed to set zone priority: {stderr}")
-            
+
             # Set zone target if specified
             if self.zone_target is not None:
-                success, _, stderr = self._run_firewall_cmd([
-                    "--permanent", f"--zone={self.zone_name}", f"--set-target={self.zone_target}"
-                ])
+                success, _, stderr = self._run_firewall_cmd(
+                    ["--permanent", f"--zone={self.zone_name}", f"--set-target={self.zone_target}"]
+                )
                 if not success:
                     self.logger.warning(f"Failed to set zone target: {stderr}")
                 else:
                     self.logger.info(f"Set zone target to: {self.zone_target}")
-            
+
             # Don't set DROP as default target - instead use specific port rules
             # This ensures only monitored ports are affected, not all traffic
-            
+
             # Add monitored IP ranges to the zone
             for ip_range in self.monitored_ips:
-                success, _, stderr = self._run_firewall_cmd([
-                    "--permanent", f"--zone={self.zone_name}", f"--add-source={ip_range}"
-                ])
+                success, _, stderr = self._run_firewall_cmd(
+                    ["--permanent", f"--zone={self.zone_name}", f"--add-source={ip_range}"]
+                )
                 if not success:
                     self.logger.warning(f"Failed to add source {ip_range} to zone: {stderr}")
-            
+
             # Add default action rules for monitored ports with low priority (high number)
             # These will be overridden by whitelist rules with higher priority (lower number)
             for port_config in self.monitored_ports:
                 port = port_config.get("port")
                 protocol = port_config.get("protocol", "tcp")
-                
+
                 # Add default action rules for both IPv4 and IPv6 with low priority (high number = 9999)
                 for family in ["ipv4", "ipv6"]:
                     default_rule = f'rule family="{family}" port protocol="{protocol}" port="{port}" {self.default_action} priority="9999"'
-                    success, _, stderr = self._run_firewall_cmd([
-                        "--permanent", f"--zone={self.zone_name}", f"--add-rich-rule={default_rule}"
-                    ])
+                    success, _, stderr = self._run_firewall_cmd(
+                        [
+                            "--permanent",
+                            f"--zone={self.zone_name}",
+                            f"--add-rich-rule={default_rule}",
+                        ]
+                    )
                     if not success:
-                        self.logger.warning(f"Failed to add {self.default_action.upper()} rule for {port}/{protocol} ({family}): {stderr}")
+                        self.logger.warning(
+                            f"Failed to add {self.default_action.upper()} rule for {port}/{protocol} ({family}): {stderr}"
+                        )
                     else:
-                        self.logger.info(f"Added {self.default_action.upper()} rule for port {port}/{protocol} ({family})")
+                        self.logger.info(
+                            f"Added {self.default_action.upper()} rule for port {port}/{protocol} ({family})"
+                        )
 
             # Reload to apply permanent changes
             success, _, stderr = self._run_firewall_cmd(["--reload"])
             if not success:
                 self.logger.error(f"Failed to reload firewall: {stderr}")
                 return False
-                
+
             self.logger.info(f"Knocker firewalld zone '{self.zone_name}' configured successfully")
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Exception during zone setup: {e}")
             return False
-            
-    def _add_or_replace_rule(self, ip_address: str, port: int, protocol: str, timeout_seconds: int) -> bool:
+
+    def _add_or_replace_rule(
+        self, ip_address: str, port: int, protocol: str, timeout_seconds: int
+    ) -> bool:
         """
         Try to add a rich rule with timeout. If firewalld reports the rule is already enabled
         (ALREADY_ENABLED / 'already in'), remove the existing rule and attempt to re-add it to
@@ -325,41 +336,66 @@ class FirewalldIntegration:
             self.logger.error(f"Failed to build rich rule for {ip_address}:{port}/{protocol}")
             return False
 
-        add_args = [f"--zone={self.zone_name}", f"--add-rich-rule={rich_rule}", f"--timeout={timeout_seconds}"]
+        add_args = [
+            f"--zone={self.zone_name}",
+            f"--add-rich-rule={rich_rule}",
+            f"--timeout={timeout_seconds}",
+        ]
 
         success, stdout, stderr = self._run_firewall_cmd(add_args)
         combined_output = " ".join(filter(None, [stdout, stderr])).upper()
 
         # If add succeeded and no warnings, we're done
-        if success and "ALREADY_ENABLED" not in combined_output and "ALREADY IN" not in combined_output and "ALREADY" not in combined_output:
+        if (
+            success
+            and "ALREADY_ENABLED" not in combined_output
+            and "ALREADY IN" not in combined_output
+            and "ALREADY" not in combined_output
+        ):
             self.logger.info(f"Added firewalld rule for {ip_address}:{port}/{protocol}")
             return True
 
         # If the command succeeded but indicates the rule already exists, attempt replace
-        if success and ("ALREADY_ENABLED" in combined_output or "ALREADY IN" in combined_output or ("ALREADY" in combined_output and "IN" in combined_output)):
-            self.logger.warning(f"firewall-cmd reported rule already exists for {ip_address}:{port}/{protocol}: {stderr or stdout}. Attempting to replace it to update TTL.")
+        if success and (
+            "ALREADY_ENABLED" in combined_output
+            or "ALREADY IN" in combined_output
+            or ("ALREADY" in combined_output and "IN" in combined_output)
+        ):
+            self.logger.warning(
+                f"firewall-cmd reported rule already exists for {ip_address}:{port}/{protocol}: {stderr or stdout}. Attempting to replace it to update TTL."
+            )
             # Try to remove the existing rule (don't fail the whole operation on remove failure)
             rem_args = [f"--zone={self.zone_name}", f"--remove-rich-rule={rich_rule}"]
             rem_success, rem_stdout, rem_stderr = self._run_firewall_cmd(rem_args, check=False)
             if not rem_success:
-                self.logger.warning(f"Failed to remove existing rule for {ip_address}:{port}/{protocol}: {rem_stderr or rem_stdout}")
+                self.logger.warning(
+                    f"Failed to remove existing rule for {ip_address}:{port}/{protocol}: {rem_stderr or rem_stdout}"
+                )
 
             # Re-add with requested timeout
             readd_success, readd_stdout, readd_stderr = self._run_firewall_cmd(add_args)
             if readd_success:
-                self.logger.info(f"Replaced firewalld rule for {ip_address}:{port}/{protocol} with new TTL={timeout_seconds}s")
+                self.logger.info(
+                    f"Replaced firewalld rule for {ip_address}:{port}/{protocol} with new TTL={timeout_seconds}s"
+                )
                 return True
             else:
-                self.logger.error(f"Failed to re-add firewalld rule for {ip_address}:{port}/{protocol} after removal: {readd_stderr}")
+                self.logger.error(
+                    f"Failed to re-add firewalld rule for {ip_address}:{port}/{protocol} after removal: {readd_stderr}"
+                )
                 return False
 
         # If initial add failed (non-zero exit), log and return False
         if not success:
-            self.logger.error(f"Failed to add firewalld rule for {ip_address}:{port}/{protocol}: {stderr}")
+            self.logger.error(
+                f"Failed to add firewalld rule for {ip_address}:{port}/{protocol}: {stderr}"
+            )
             return False
 
         # Fallback success
-        self.logger.info(f"Added firewalld rule for {ip_address}:{port}/{protocol} (warning present)")
+        self.logger.info(
+            f"Added firewalld rule for {ip_address}:{port}/{protocol} (warning present)"
+        )
         return True
 
     def add_whitelist_rule(self, ip_address: str, expiry_time: int) -> bool:
@@ -383,7 +419,9 @@ class FirewalldIntegration:
         # Calculate timeout - ensure it's positive
         timeout_seconds = expiry_time - int(time.time())
         if timeout_seconds <= 0:
-            self.logger.error(f"Invalid timeout calculated: {timeout_seconds} seconds (expiry: {expiry_time}, current: {int(time.time())})")
+            self.logger.error(
+                f"Invalid timeout calculated: {timeout_seconds} seconds (expiry: {expiry_time}, current: {int(time.time())})"
+            )
             return False
 
         success_count = 0
@@ -403,178 +441,194 @@ class FirewalldIntegration:
                 if rich_rule:
                     added_rules.append(rich_rule)
             else:
-                self.logger.error(f"Failed to ensure firewalld rule for {ip_address}:{port}/{protocol}")
+                self.logger.error(
+                    f"Failed to ensure firewalld rule for {ip_address}:{port}/{protocol}"
+                )
 
         if success_count == total_rules:
-            self.logger.info(f"Successfully added all {total_rules} firewalld rules for {ip_address}")
+            self.logger.info(
+                f"Successfully added all {total_rules} firewalld rules for {ip_address}"
+            )
             return True
         else:
             # Partial failure - rollback added rules
-            self.logger.error(f"Only {success_count}/{total_rules} firewalld rules added for {ip_address}")
+            self.logger.error(
+                f"Only {success_count}/{total_rules} firewalld rules added for {ip_address}"
+            )
             self._rollback_rules(added_rules, ip_address)
             return False
-    
+
     def _rollback_rules(self, rules: List[str], ip_address: str):
         """Roll back successfully added rules on partial failure."""
         self.logger.info(f"Rolling back {len(rules)} firewalld rules for {ip_address}")
         for rule in rules:
-            success, stdout, stderr = self._run_firewall_cmd([
-                f"--zone={self.zone_name}", f"--remove-rich-rule={rule}"
-            ], check=False)
+            success, stdout, stderr = self._run_firewall_cmd(
+                [f"--zone={self.zone_name}", f"--remove-rich-rule={rule}"], check=False
+            )
             if not success:
                 self.logger.warning(f"Failed to rollback rule '{rule}': {stderr}")
-    
+
     def remove_whitelist_rule(self, ip_address: str) -> bool:
         """
         Remove firewalld rules for an IP address.
-        
+
         Args:
             ip_address: IP address or CIDR to remove from whitelist
-            
+
         Returns:
             True if rules removed successfully, False otherwise
         """
         if not self.is_enabled():
             return True
-            
+
         if not self.is_firewalld_available():
             self.logger.error("Firewalld not available for removing whitelist rule")
             return False
-            
+
         success_count = 0
         total_rules = len(self.monitored_ports)
-        
+
         for port_config in self.monitored_ports:
             port = port_config.get("port")
             protocol = port_config.get("protocol", "tcp")
-            
+
             # Build rich rule using helper function
             rich_rule = self._build_rich_rule(ip_address, port, protocol)
             if not rich_rule:
-                self.logger.warning(f"Failed to build rich rule for removal: {ip_address}:{port}/{protocol}")
+                self.logger.warning(
+                    f"Failed to build rich rule for removal: {ip_address}:{port}/{protocol}"
+                )
                 continue
-            
-            success, stdout, stderr = self._run_firewall_cmd([
-                f"--zone={self.zone_name}", f"--remove-rich-rule={rich_rule}"
-            ], check=False)
-            
+
+            success, stdout, stderr = self._run_firewall_cmd(
+                [f"--zone={self.zone_name}", f"--remove-rich-rule={rich_rule}"], check=False
+            )
+
             if success:
                 success_count += 1
                 self.logger.info(f"Removed firewalld rule for {ip_address}:{port}/{protocol}")
             else:
                 # Don't log as error if rule doesn't exist (might have expired)
-                self.logger.debug(f"Could not remove firewalld rule for {ip_address}:{port}/{protocol}: {stderr}")
-        
-        self.logger.info(f"Processed {success_count}/{total_rules} firewalld rule removals for {ip_address}")
+                self.logger.debug(
+                    f"Could not remove firewalld rule for {ip_address}:{port}/{protocol}: {stderr}"
+                )
+
+        self.logger.info(
+            f"Processed {success_count}/{total_rules} firewalld rule removals for {ip_address}"
+        )
         return True  # Return True even if some rules weren't found (they may have expired)
-    
+
     def get_active_rules(self) -> List[FirewalldRule]:
         """
         Get list of currently active firewalld rules in the knocker zone.
-        
+
         Returns:
             List of FirewalldRule objects representing active rules
         """
         if not self.is_enabled() or not self.is_firewalld_available():
             return []
-            
+
         active_rules = []
-        
+
         # Get rich rules from the zone
-        success, stdout, stderr = self._run_firewall_cmd([
-            f"--zone={self.zone_name}", "--list-rich-rules"
-        ], check=False)
-        
+        success, stdout, stderr = self._run_firewall_cmd(
+            [f"--zone={self.zone_name}", "--list-rich-rules"], check=False
+        )
+
         if not success:
             self.logger.warning(f"Failed to get active rules: {stderr}")
             return []
-        
+
         # Parse rich rules (this is a simplified parser)
         # Format: rule family="ipv4" source address="1.2.3.4" port protocol="tcp" port="80" accept
-        for line in stdout.split('\n'):
-            if line.strip() and 'source address=' in line and 'port=' in line:
+        for line in stdout.split("\n"):
+            if line.strip() and "source address=" in line and "port=" in line:
                 try:
                     # Extract IP address
                     ip_start = line.find('source address="') + 16
                     ip_end = line.find('"', ip_start)
                     ip_address = line[ip_start:ip_end]
-                    
+
                     # Extract port
                     port_start = line.rfind('port="') + 6
                     port_end = line.find('"', port_start)
                     port = int(line[port_start:port_end])
-                    
+
                     # Extract protocol
                     proto_start = line.find('protocol="') + 10
                     proto_end = line.find('"', proto_start)
                     protocol = line[proto_start:proto_end]
-                    
+
                     # For now, we can't easily get expiry time from firewalld
                     # We'll need to cross-reference with whitelist.json
                     rule = FirewalldRule(ip_address, port, protocol, 0)
                     active_rules.append(rule)
-                    
+
                 except (ValueError, IndexError) as e:
                     self.logger.warning(f"Failed to parse firewalld rule: {line} - {e}")
                     continue
-        
+
         return active_rules
-    
+
     def restore_missing_rules(self, whitelist: Dict[str, int]) -> bool:
         """
         Compare whitelist.json with active firewalld rules and restore missing ones.
-        
+
         Args:
             whitelist: Dictionary of IP addresses to expiry times from whitelist.json
-            
+
         Returns:
             True if all missing rules restored successfully, False otherwise
         """
         if not self.is_enabled():
             return True
-            
+
         current_time = int(time.time())
         active_rules = self.get_active_rules()
-        
+
         # Create a set of (ip, port, protocol) tuples for active rules
         active_rule_set = set()
         for rule in active_rules:
             active_rule_set.add((rule.ip_address, rule.port, rule.protocol))
-        
+
         missing_rules = 0
         restored_rules = 0
-        
+
         # Check each whitelist entry
         for ip_address, expiry_time in whitelist.items():
             # Skip expired entries
             if expiry_time <= current_time:
                 continue
-                
+
             # Check if rules exist for this IP for all monitored ports
             for port_config in self.monitored_ports:
                 port = port_config.get("port")
                 protocol = port_config.get("protocol", "tcp")
-                
+
                 rule_tuple = (ip_address, port, protocol)
                 if rule_tuple not in active_rule_set:
                     missing_rules += 1
-                    self.logger.info(f"Missing firewalld rule detected: {ip_address}:{port}/{protocol}")
-                    
+                    self.logger.info(
+                        f"Missing firewalld rule detected: {ip_address}:{port}/{protocol}"
+                    )
+
                     # Restore the rule with remaining TTL
                     remaining_ttl = expiry_time - current_time
                     if self._add_single_rule(ip_address, port, protocol, remaining_ttl):
                         restored_rules += 1
-        
+
         if missing_rules > 0:
             self.logger.info(f"Restored {restored_rules}/{missing_rules} missing firewalld rules")
         else:
             self.logger.info("No missing firewalld rules detected")
-        
+
         return restored_rules == missing_rules
-    
-    def _add_single_rule(self, ip_address: str, port: int, protocol: str, timeout_seconds: int) -> bool:
+
+    def _add_single_rule(
+        self, ip_address: str, port: int, protocol: str, timeout_seconds: int
+    ) -> bool:
         """Add a single firewalld rule with timeout.
-        
+
         This now delegates to _add_or_replace_rule so that behavior for handling
         "ALREADY_ENABLED" warnings is consistent between normal adds and restoration.
         """
@@ -582,7 +636,7 @@ class FirewalldIntegration:
         if timeout_seconds <= 0:
             self.logger.error(f"Invalid timeout for rule restoration: {timeout_seconds} seconds")
             return False
-    
+
         # Delegate to add-or-replace helper which handles ALREADY_ENABLED collisions
         return self._add_or_replace_rule(ip_address, port, protocol, timeout_seconds)
 

--- a/src/firewalld.py
+++ b/src/firewalld.py
@@ -241,6 +241,12 @@ class FirewalldIntegration:
         if not self.is_firewalld_available():
             return False
 
+        if not self._check_firewalld_version():
+            self.logger.error(
+                "Firewalld 2.0 or newer is required before configuring zone priority."
+            )
+            return False
+
         try:
             # Check if zone already exists
             success, stdout, _ = self._run_firewall_cmd(["--get-zones"], check=False)
@@ -355,8 +361,9 @@ class FirewalldIntegration:
             self.logger.info(f"Added firewalld rule for {ip_address}:{port}/{protocol}")
             return True
 
-        # If the command succeeded but indicates the rule already exists, attempt replace
-        if success and (
+        # Attempt replace whenever firewalld indicates the rule already exists, even if
+        # it returned a non-zero exit status.
+        if (
             "ALREADY_ENABLED" in combined_output
             or "ALREADY IN" in combined_output
             or ("ALREADY" in combined_output and "IN" in combined_output)

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,9 @@ except ImportError:  # pragma: no cover - fallback for direct module execution
     from models import KnockRequest, KnockResponse, HealthResponse, ErrorResponse
 
 
+MAX_TTL = 315360000
+
+
 @lru_cache()
 def get_settings() -> Dict:
     """
@@ -531,7 +534,6 @@ async def knock(
             )
 
         # Prevent extremely large TTL values (max 10 years = 315360000 seconds)
-        MAX_TTL = 315360000
         if requested_ttl > MAX_TTL:
             logging.warning(
                 f"TTL {requested_ttl} exceeds maximum allowed ({MAX_TTL}) from {client_ip}."

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional, Dict, Union, Tuple
 from functools import lru_cache
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Request, Response, status, Depends, HTTPException
+from fastapi import FastAPI, Request, Response, status, Depends
 from fastapi.responses import JSONResponse
 from fastapi.openapi.docs import (
     get_redoc_html,
@@ -14,7 +14,7 @@ from fastapi.openapi.docs import (
     get_swagger_ui_oauth2_redirect_html,
 )
 from fastapi.exceptions import RequestValidationError
-from starlette.exceptions import HTTPException as StarletteHTTPException
+
 try:
     from . import core
     from . import config
@@ -25,6 +25,7 @@ except ImportError:  # pragma: no cover - fallback for direct module execution
     import config
     import firewalld
     from models import KnockRequest, KnockResponse, HealthResponse, ErrorResponse
+
 
 @lru_cache()
 def get_settings() -> Dict:
@@ -37,6 +38,7 @@ def get_settings() -> Dict:
     core.ensure_runtime_state(settings)
     return settings
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -44,23 +46,23 @@ async def lifespan(app: FastAPI):
     On startup, it performs cleanup of expired IPs and initializes firewalld.
     """
     logging.info("Knocker service starting up...")
-    
+
     settings = get_settings()
     runtime_state = core.start_runtime_state(settings)
     runtime_state.whitelist.compact_expired()
-    
+
     # Generate and persist OpenAPI schema
     await generate_and_persist_openapi(app, settings)
-    
+
     # Initialize firewalld integration
     firewalld_integration = firewalld.initialize_firewalld(settings)
     if firewalld_integration and firewalld_integration.is_enabled():
         logging.info("Firewalld integration is enabled")
-        
+
         # Setup firewalld zone
         if firewalld_integration.setup_knocker_zone():
             logging.info("Firewalld zone setup completed successfully")
-            
+
             # Restore missing rules from whitelist
             whitelist = runtime_state.whitelist.active_snapshot()
             if firewalld_integration.restore_missing_rules(whitelist):
@@ -68,10 +70,12 @@ async def lifespan(app: FastAPI):
             else:
                 logging.warning("Some firewalld rules could not be restored")
         else:
-            logging.error("Failed to setup firewalld zone - firewalld integration may not work properly")
+            logging.error(
+                "Failed to setup firewalld zone - firewalld integration may not work properly"
+            )
     else:
         logging.info("Firewalld integration is disabled")
-    
+
     yield
     core.stop_runtime_state(settings)
     logging.info("Knocker service shutting down.")
@@ -91,8 +95,7 @@ def _remove_documentation_routes(app: FastAPI) -> None:
 
     router = app.router
     router.routes = [
-        route for route in router.routes
-        if getattr(route, "path", None) not in doc_paths
+        route for route in router.routes if getattr(route, "path", None) not in doc_paths
     ]
 
     routes_by_name = getattr(router, "routes_by_name", None)
@@ -160,7 +163,9 @@ async def generate_and_persist_openapi(app: FastAPI, settings: Dict):
         try:
             if output_path.exists():
                 output_path.unlink()
-                logging.info(f"OpenAPI schema removed because documentation is disabled: {output_path}")
+                logging.info(
+                    f"OpenAPI schema removed because documentation is disabled: {output_path}"
+                )
         except Exception as exc:
             logging.warning(f"Failed to remove OpenAPI schema file at {output_path}: {exc}")
         return
@@ -174,7 +179,7 @@ async def generate_and_persist_openapi(app: FastAPI, settings: Dict):
     app.openapi_schema = None
     try:
         openapi_schema = app.openapi()
-        with output_path.open('w', encoding='utf-8') as f:
+        with output_path.open("w", encoding="utf-8") as f:
             json.dump(openapi_schema, f, indent=2)
         logging.info(f"OpenAPI schema generated and saved to {output_path}")
     except Exception as exc:
@@ -211,15 +216,9 @@ A dynamic IP whitelisting service that works with reverse proxy authorization.
 """,
     "version": "1.0.0",
     "openapi_tags": [
-        {
-            "name": "Authentication", 
-            "description": "Endpoints for IP whitelisting and verification"
-        },
-        {
-            "name": "System", 
-            "description": "Health monitoring and system status"
-        }
-    ]
+        {"name": "Authentication", "description": "Endpoints for IP whitelisting and verification"},
+        {"name": "System", "description": "Health monitoring and system status"},
+    ],
 }
 app = FastAPI(**app_config)
 
@@ -231,7 +230,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     settings_provider = app.dependency_overrides.get(get_settings, get_settings)
     settings = settings_provider()
     allowed_origin = settings.get("cors", {}).get("allowed_origin", "*")
-    
+
     # Extract a user-friendly error message
     error_msg = "Invalid request data."
     if exc.errors():
@@ -242,15 +241,18 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
             error_msg = "Invalid TTL specified. Must be a positive integer."
         elif "ip_address" in str(first_error.get("loc", [])):
             error_msg = "Invalid IP address or CIDR notation in request body."
-    
+
     return JSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,
         content={"error": error_msg},
-        headers={"Access-Control-Allow-Origin": allowed_origin}
+        headers={"Access-Control-Allow-Origin": allowed_origin},
     )
 
+
 # --- Dependency for getting the real client IP ---
-def _resolve_request_context(request: Request, settings: dict) -> Tuple[Optional[str], bool, Optional[str], str]:
+def _resolve_request_context(
+    request: Request, settings: dict
+) -> Tuple[Optional[str], bool, Optional[str], str]:
     """Resolve client IP and forwarded request metadata from trusted proxies only."""
     direct_ip = request.client.host if request.client else None
 
@@ -292,7 +294,10 @@ def get_client_ip(request: Request, settings: Optional[dict] = None) -> Optional
         direct_ip = request.headers.get("x-knocker-test-direct-ip", "127.0.0.1")
     return direct_ip
 
-def get_client_ip_dependency(request: Request, settings: dict = Depends(get_settings)) -> Optional[str]:
+
+def get_client_ip_dependency(
+    request: Request, settings: dict = Depends(get_settings)
+) -> Optional[str]:
     """Dependency wrapper for get_client_ip that includes settings."""
     return get_client_ip(request, settings)
 
@@ -304,14 +309,16 @@ def get_request_context_dependency(
     """Dependency wrapper for trusted proxy metadata resolution."""
     return _resolve_request_context(request, settings)
 
+
 # --- API Endpoints ---
 
+
 @app.options(
-    "/knock", 
+    "/knock",
     tags=["Authentication"],
     summary="CORS Preflight",
     description="Handles OPTIONS requests for CORS preflight checks.",
-    status_code=204
+    status_code=204,
 )
 async def knock_options(settings: dict = Depends(get_settings)):
     """
@@ -324,18 +331,22 @@ async def knock_options(settings: dict = Depends(get_settings)):
             "Access-Control-Allow-Origin": allowed_origin,
             "Access-Control-Allow-Methods": "POST, OPTIONS",
             "Access-Control-Allow-Headers": "X-Api-Key, Content-Type",
-        }
+        },
     )
 
+
 @app.post(
-    "/knock", 
+    "/knock",
     response_model=KnockResponse,
     responses={
         200: {"model": KnockResponse, "description": "Successfully whitelisted the IP"},
         400: {"model": ErrorResponse, "description": "Bad request - invalid parameters"},
         401: {"model": ErrorResponse, "description": "Unauthorized - invalid or missing API key"},
         403: {"model": ErrorResponse, "description": "Forbidden - insufficient permissions"},
-        500: {"model": ErrorResponse, "description": "Internal server error - failed to persist whitelist or create firewall rules"}
+        500: {
+            "model": ErrorResponse,
+            "description": "Internal server error - failed to persist whitelist or create firewall rules",
+        },
     },
     tags=["Authentication"],
     summary="Whitelist IP Address",
@@ -347,14 +358,14 @@ async def knock_options(settings: dict = Depends(get_settings)):
     * Can whitelist a different IP/CIDR if the API key has remote whitelist permission
     * TTL can be specified but will be capped by the API key's maximum TTL
     """,
-    status_code=status.HTTP_200_OK
+    status_code=status.HTTP_200_OK,
 )
 async def knock(
     request: Request,
     response: Response,
     body: Optional[Union[KnockRequest, Dict]] = None,
     client_ip: str = Depends(get_client_ip_dependency),
-    settings: dict = Depends(get_settings)
+    settings: dict = Depends(get_settings),
 ):
     api_key = request.headers.get("X-Api-Key")
     allowed_origin = settings.get("cors", {}).get("allowed_origin", "*")
@@ -374,7 +385,7 @@ async def knock(
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content={"error": "Could not determine client IP."},
-            headers={"Access-Control-Allow-Origin": allowed_origin}
+            headers={"Access-Control-Allow-Origin": allowed_origin},
         )
 
     api_key_record = core.get_api_key_record(api_key, settings)
@@ -389,13 +400,17 @@ async def knock(
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
             content={"error": "Invalid or missing API key."},
-            headers={"Access-Control-Allow-Origin": allowed_origin}
+            headers={"Access-Control-Allow-Origin": allowed_origin},
         )
 
     ip_to_whitelist = client_ip
     if body:
         # Handle both KnockRequest objects and raw dicts for backward compatibility
-        ip_address = getattr(body, 'ip_address', None) if hasattr(body, 'ip_address') else body.get('ip_address')
+        ip_address = (
+            getattr(body, "ip_address", None)
+            if hasattr(body, "ip_address")
+            else body.get("ip_address")
+        )
         if ip_address:
             # Security: Validate input size to prevent DoS
             if not isinstance(ip_address, str):
@@ -409,9 +424,9 @@ async def knock(
                 return JSONResponse(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     content={"error": "IP address must be a string."},
-                    headers={"Access-Control-Allow-Origin": allowed_origin}
+                    headers={"Access-Control-Allow-Origin": allowed_origin},
                 )
-            
+
             if len(ip_address) > 100:  # Max length for IPv6 with CIDR
                 logging.warning(f"IP address too long ({len(ip_address)} chars) from {client_ip}.")
                 if not core.record_knock_attempt(settings, rate_limit_actor, "failure"):
@@ -423,9 +438,9 @@ async def knock(
                 return JSONResponse(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     content={"error": "IP address or CIDR notation too long."},
-                    headers={"Access-Control-Allow-Origin": allowed_origin}
+                    headers={"Access-Control-Allow-Origin": allowed_origin},
                 )
-            
+
             if not api_key_record.allow_remote_whitelist:
                 logging.warning(f"API key used by {client_ip} lacks remote whitelist permission.")
                 if not core.record_knock_attempt(settings, rate_limit_actor, "failure"):
@@ -437,11 +452,13 @@ async def knock(
                 return JSONResponse(
                     status_code=status.HTTP_403_FORBIDDEN,
                     content={"error": "API key lacks remote whitelist permission."},
-                    headers={"Access-Control-Allow-Origin": allowed_origin}
+                    headers={"Access-Control-Allow-Origin": allowed_origin},
                 )
-            
+
             if not core.is_valid_ip_or_cidr(ip_address):
-                logging.warning(f"Invalid IP address or CIDR notation '{ip_address}' in request body from {client_ip}.")
+                logging.warning(
+                    f"Invalid IP address or CIDR notation '{ip_address}' in request body from {client_ip}."
+                )
                 if not core.record_knock_attempt(settings, rate_limit_actor, "failure"):
                     return JSONResponse(
                         status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -451,9 +468,9 @@ async def knock(
                 return JSONResponse(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     content={"error": "Invalid IP address or CIDR notation in request body."},
-                    headers={"Access-Control-Allow-Origin": allowed_origin}
+                    headers={"Access-Control-Allow-Origin": allowed_origin},
                 )
-            
+
             # Security check: prevent overly broad CIDR ranges
             if not core.is_safe_cidr_range(ip_address):
                 logging.warning(f"Unsafe CIDR range '{ip_address}' rejected from {client_ip}.")
@@ -466,20 +483,24 @@ async def knock(
                 return JSONResponse(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     content={"error": "CIDR range too broad. Maximum 65536 addresses allowed."},
-                    headers={"Access-Control-Allow-Origin": allowed_origin}
+                    headers={"Access-Control-Allow-Origin": allowed_origin},
                 )
-            
+
             ip_to_whitelist = ip_address
 
     max_ttl = api_key_record.max_ttl
-    requested_ttl = getattr(body, 'ttl', None) if hasattr(body, 'ttl') else (body.get('ttl') if body else None)
-    
+    requested_ttl = (
+        getattr(body, "ttl", None) if hasattr(body, "ttl") else (body.get("ttl") if body else None)
+    )
+
     effective_ttl = max_ttl
 
     if requested_ttl is not None:
         # Comprehensive TTL validation
         if not isinstance(requested_ttl, int):
-            logging.warning(f"Invalid TTL type '{type(requested_ttl).__name__}' specified by {client_ip}.")
+            logging.warning(
+                f"Invalid TTL type '{type(requested_ttl).__name__}' specified by {client_ip}."
+            )
             if not core.record_knock_attempt(settings, rate_limit_actor, "failure"):
                 return JSONResponse(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -489,12 +510,14 @@ async def knock(
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 content={"error": "Invalid TTL specified. Must be a positive integer."},
-                headers={"Access-Control-Allow-Origin": allowed_origin}
+                headers={"Access-Control-Allow-Origin": allowed_origin},
             )
-        
+
         # Check for edge cases: 0, negative, and excessively large values
         if requested_ttl <= 0:
-            logging.warning(f"Invalid TTL '{requested_ttl}' (must be positive) specified by {client_ip}.")
+            logging.warning(
+                f"Invalid TTL '{requested_ttl}' (must be positive) specified by {client_ip}."
+            )
             if not core.record_knock_attempt(settings, rate_limit_actor, "failure"):
                 return JSONResponse(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -504,13 +527,15 @@ async def knock(
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 content={"error": "Invalid TTL specified. Must be a positive integer."},
-                headers={"Access-Control-Allow-Origin": allowed_origin}
+                headers={"Access-Control-Allow-Origin": allowed_origin},
             )
-        
+
         # Prevent extremely large TTL values (max 10 years = 315360000 seconds)
         MAX_TTL = 315360000
         if requested_ttl > MAX_TTL:
-            logging.warning(f"TTL {requested_ttl} exceeds maximum allowed ({MAX_TTL}) from {client_ip}.")
+            logging.warning(
+                f"TTL {requested_ttl} exceeds maximum allowed ({MAX_TTL}) from {client_ip}."
+            )
             if not core.record_knock_attempt(settings, rate_limit_actor, "failure"):
                 return JSONResponse(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -519,10 +544,12 @@ async def knock(
                 )
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                content={"error": f"TTL too large. Maximum allowed is {MAX_TTL} seconds (10 years)."},
-                headers={"Access-Control-Allow-Origin": allowed_origin}
+                content={
+                    "error": f"TTL too large. Maximum allowed is {MAX_TTL} seconds (10 years)."
+                },
+                headers={"Access-Control-Allow-Origin": allowed_origin},
             )
-        
+
         effective_ttl = min(requested_ttl, max_ttl)
 
     expiry_time = int(time.time()) + effective_ttl
@@ -534,17 +561,21 @@ async def knock(
             content={"error": "Too many knock attempts."},
             headers={"Access-Control-Allow-Origin": allowed_origin},
         )
-    
+
     # Add to whitelist with firewalld integration
     # This will add firewalld rules BEFORE updating whitelist.json if firewalld is enabled
     error_content = ErrorResponse(
         error="Internal server error: whitelist persistence or firewall configuration failed."
     ).model_dump()
     try:
-        whitelisted = core.add_ip_to_whitelist_with_firewalld(ip_to_whitelist, expiry_time, settings)
+        whitelisted = core.add_ip_to_whitelist_with_firewalld(
+            ip_to_whitelist, expiry_time, settings
+        )
     except Exception:
         core.release_knock_attempt(settings, rate_limit_actor, "success", success_reservation)
-        logging.exception("Failed to whitelist %s. Request from %s rejected.", ip_to_whitelist, client_ip)
+        logging.exception(
+            "Failed to whitelist %s. Request from %s rejected.", ip_to_whitelist, client_ip
+        )
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content=error_content,
@@ -563,15 +594,20 @@ async def knock(
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content=error_content,
-            headers={"Access-Control-Allow-Origin": allowed_origin}
+            headers={"Access-Control-Allow-Origin": allowed_origin},
         )
-    
+
     # Log with limited information; avoid logging API key names at INFO level.
     # API key name is available at DEBUG level for troubleshooting only.
     api_key_name = api_key_record.name
     logger = logging.getLogger("uvicorn.error")
     # Reduce logging to DEBUG only to avoid information disclosure in INFO-level logs.
-    logger.debug("Successfully whitelisted %s for %d seconds. Requested by %s.", ip_to_whitelist, effective_ttl, client_ip)
+    logger.debug(
+        "Successfully whitelisted %s for %d seconds. Requested by %s.",
+        ip_to_whitelist,
+        effective_ttl,
+        client_ip,
+    )
     if api_key_name:
         logger.debug("API key used: %s", api_key_name)
 
@@ -583,13 +619,14 @@ async def knock(
         expires_in_seconds=effective_ttl,
     )
 
+
 @app.get(
-    "/health", 
+    "/health",
     response_model=HealthResponse,
     tags=["System"],
     summary="Health Check",
     description="Verify that the Knocker service is running and operational.",
-    status_code=status.HTTP_200_OK
+    status_code=status.HTTP_200_OK,
 )
 async def health_check(settings: dict = Depends(get_settings)):
     """
@@ -602,7 +639,7 @@ async def health_check(settings: dict = Depends(get_settings)):
             logging.error("Health check failed: No API keys configured")
             return JSONResponse(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                content={"status": "unhealthy", "error": "No API keys configured"}
+                content={"status": "unhealthy", "error": "No API keys configured"},
             )
 
         whitelist_path = runtime_state.whitelist.storage_path
@@ -611,14 +648,14 @@ async def health_check(settings: dict = Depends(get_settings)):
             logging.error("Health check failed: Whitelist storage is not readable and writable")
             return JSONResponse(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                content={"status": "unhealthy", "error": "Whitelist storage not accessible"}
+                content={"status": "unhealthy", "error": "Whitelist storage not accessible"},
             )
 
         if not os.access(whitelist_path.parent, os.R_OK | os.W_OK | os.X_OK):
             logging.error("Health check failed: Whitelist storage directory is not accessible")
             return JSONResponse(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                content={"status": "unhealthy", "error": "Whitelist storage not accessible"}
+                content={"status": "unhealthy", "error": "Whitelist storage not accessible"},
             )
 
         try:
@@ -628,7 +665,7 @@ async def health_check(settings: dict = Depends(get_settings)):
             logging.error(f"Health check failed: Whitelist storage probe failed: {exc}")
             return JSONResponse(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                content={"status": "unhealthy", "error": "Whitelist storage not accessible"}
+                content={"status": "unhealthy", "error": "Whitelist storage not accessible"},
             )
 
         return HealthResponse(status="ok")
@@ -636,14 +673,15 @@ async def health_check(settings: dict = Depends(get_settings)):
         logging.error(f"Health check failed with unexpected error: {e}")
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            content={"status": "unhealthy", "error": "Internal error"}
+            content={"status": "unhealthy", "error": "Internal error"},
         )
+
 
 @app.get(
     "/verify",
     responses={
         200: {"description": "IP is authorized - access granted"},
-        401: {"description": "IP is not authorized - access denied"}
+        401: {"description": "IP is not authorized - access denied"},
     },
     tags=["Authentication"],
     summary="Verify IP Authorization",
@@ -659,12 +697,14 @@ async def health_check(settings: dict = Depends(get_settings)):
     * Uses X-Forwarded-For header when coming from trusted proxies
     * Uses X-Forwarded-Uri header to check excluded paths
     """,
-    status_code=status.HTTP_200_OK
+    status_code=status.HTTP_200_OK,
 )
 async def verify(
     request: Request,
-    request_context: Tuple[Optional[str], bool, Optional[str], str] = Depends(get_request_context_dependency),
-    settings: dict = Depends(get_settings)
+    request_context: Tuple[Optional[str], bool, Optional[str], str] = Depends(
+        get_request_context_dependency
+    ),
+    settings: dict = Depends(get_settings),
 ):
     client_ip, forwarded_headers_trusted, request_host, request_path = request_context
     runtime_state = core.ensure_runtime_state(settings)

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,7 @@
 """
 Pydantic models for request/response schemas in the Knocker API.
 """
+
 from typing import Optional
 from pydantic import BaseModel, Field, field_validator
 import ipaddress
@@ -8,19 +9,20 @@ import ipaddress
 
 class KnockRequest(BaseModel):
     """Request schema for the knock endpoint."""
+
     ip_address: Optional[str] = Field(
         None,
         description="IP address or CIDR range to whitelist. If not provided, the client's IP is used.",
-        json_schema_extra={"example": "192.168.1.100"}
+        json_schema_extra={"example": "192.168.1.100"},
     )
     ttl: Optional[int] = Field(
         None,
         description="Time-to-live in seconds for the whitelist entry. Must be positive integer.",
         json_schema_extra={"example": 3600},
-        gt=0
+        gt=0,
     )
 
-    @field_validator('ip_address')
+    @field_validator("ip_address")
     @classmethod
     def validate_ip_address(cls, v):
         if v is None:
@@ -40,31 +42,31 @@ class KnockRequest(BaseModel):
 
 class KnockResponse(BaseModel):
     """Response schema for successful knock requests."""
+
     whitelisted_entry: str = Field(
         description="The IP address or CIDR range that was added to the whitelist",
-        json_schema_extra={"example": "192.168.1.100"}
+        json_schema_extra={"example": "192.168.1.100"},
     )
     expires_at: int = Field(
         description="Unix timestamp when the whitelist entry will expire",
-        json_schema_extra={"example": 1640995200}
+        json_schema_extra={"example": 1640995200},
     )
     expires_in_seconds: int = Field(
         description="Number of seconds until the entry expires (actual TTL applied)",
-        json_schema_extra={"example": 3600}
+        json_schema_extra={"example": 3600},
     )
 
 
 class HealthResponse(BaseModel):
     """Response schema for health check endpoint."""
-    status: str = Field(
-        description="Service status indicator",
-        json_schema_extra={"example": "ok"}
-    )
+
+    status: str = Field(description="Service status indicator", json_schema_extra={"example": "ok"})
 
 
 class ErrorResponse(BaseModel):
     """Response schema for error responses."""
+
     error: str = Field(
         description="Error message describing what went wrong",
-        json_schema_extra={"example": "Invalid or missing API key."}
+        json_schema_extra={"example": "Invalid or missing API key."},
     )

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,0 @@
-fastapi
-uvicorn
-pyyaml
-pytest
-httpx

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,20 +5,26 @@ from src import core
 
 # --- Test IP/CIDR Validation ---
 
-@pytest.mark.parametrize(("address", "expected"), [
-    ("192.168.1.1", True),
-    ("2001:db8::1", True),
-    ("10.0.0.0/8", True),
-    ("2001:db8:abcd::/48", True),
-    ("not-an-ip", False),
-    ("192.168.1.1/33", False),
-    ("2001:db8::/129", False),
-])
+
+@pytest.mark.parametrize(
+    ("address", "expected"),
+    [
+        ("192.168.1.1", True),
+        ("2001:db8::1", True),
+        ("10.0.0.0/8", True),
+        ("2001:db8:abcd::/48", True),
+        ("not-an-ip", False),
+        ("192.168.1.1/33", False),
+        ("2001:db8::/129", False),
+    ],
+)
 def test_is_valid_ip_or_cidr(address, expected):
     """Tests validation for various IPv4, IPv6, and CIDR formats."""
     assert core.is_valid_ip_or_cidr(address) == expected
 
+
 # --- Test Whitelist Logic ---
+
 
 def test_ip_is_whitelisted(mock_settings):
     """Tests if an IP is correctly identified within a whitelisted CIDR."""
@@ -26,11 +32,13 @@ def test_ip_is_whitelisted(mock_settings):
     whitelist = {"192.168.1.0/24": now + 3600}
     assert core.is_ip_whitelisted("192.168.1.100", whitelist, mock_settings) == True
 
+
 def test_ip_is_not_whitelisted(mock_settings):
     """Tests if an IP outside a whitelisted CIDR is correctly rejected."""
     now = int(time.time())
     whitelist = {"192.168.1.0/24": now + 3600}
     assert core.is_ip_whitelisted("10.10.10.10", whitelist, mock_settings) == False
+
 
 def test_ipv6_is_whitelisted(mock_settings):
     """Tests if an IPv6 address is correctly identified within a whitelisted CIDR."""
@@ -38,11 +46,13 @@ def test_ipv6_is_whitelisted(mock_settings):
     whitelist = {"2001:db8:abcd::/48": now + 3600}
     assert core.is_ip_whitelisted("2001:db8:abcd:0001::1", whitelist, mock_settings) == True
 
+
 def test_expired_ip_is_not_whitelisted(mock_settings):
     """Tests if an IP with an expired timestamp is correctly rejected."""
     now = int(time.time())
-    whitelist = {"1.1.1.1/32": now - 100} # Expired
+    whitelist = {"1.1.1.1/32": now - 100}  # Expired
     assert core.is_ip_whitelisted("1.1.1.1", whitelist, mock_settings) == False
+
 
 def test_is_ip_whitelisted_with_invalid_ip_input(mock_settings):
     """Tests that the function handles invalid IP input gracefully."""
@@ -50,11 +60,13 @@ def test_is_ip_whitelisted_with_invalid_ip_input(mock_settings):
     whitelist = {"192.168.1.0/24": now + 3600}
     assert core.is_ip_whitelisted("not-a-real-ip", whitelist, mock_settings) == False
 
+
 def test_always_allowed_ip_is_whitelisted(mock_settings):
     """Tests that an IP in the always-allowed list is always whitelisted."""
     mock_settings["security"] = {"always_allowed_ips": ["10.20.30.40"]}
-    whitelist = {} # Empty dynamic whitelist
+    whitelist = {}  # Empty dynamic whitelist
     assert core.is_ip_whitelisted("10.20.30.40", whitelist, mock_settings) == True
+
 
 def test_always_allowed_cidr_is_whitelisted(mock_settings):
     """Tests that an IP within an always-allowed CIDR is always whitelisted."""
@@ -62,7 +74,9 @@ def test_always_allowed_cidr_is_whitelisted(mock_settings):
     whitelist = {}
     assert core.is_ip_whitelisted("10.20.30.50", whitelist, mock_settings) == True
 
+
 # --- Test Path Exclusion ---
+
 
 def test_path_is_excluded(mock_settings):
     """Tests that a path in the excluded list is correctly identified."""
@@ -70,12 +84,15 @@ def test_path_is_excluded(mock_settings):
     assert core.is_path_excluded("/api/health/check", mock_settings) == True
     assert core.is_path_excluded("/metrics", mock_settings) == True
 
+
 def test_path_is_not_excluded(mock_settings):
     """Tests that a path not in the excluded list is correctly rejected."""
     mock_settings["security"] = {"excluded_paths": ["/api/health"]}
     assert core.is_path_excluded("/api/v1/status", mock_settings) == False
 
+
 # --- Test Permissions & Key Helpers ---
+
 
 @pytest.fixture
 def mock_settings():
@@ -87,57 +104,73 @@ def mock_settings():
         ]
     }
 
+
 def test_can_whitelist_remote_with_permission(mock_settings):
     """Tests that a key with permission returns True."""
     assert core.can_whitelist_remote("admin_key", mock_settings) == True
+
 
 def test_can_whitelist_remote_without_permission(mock_settings):
     """Tests that a key without permission returns False."""
     assert core.can_whitelist_remote("user_key", mock_settings) == False
 
+
 def test_can_whitelist_remote_with_nonexistent_key(mock_settings):
     """Tests that a non-existent key returns False."""
     assert core.can_whitelist_remote("fake_key", mock_settings) == False
+
 
 def test_get_max_ttl_for_key(mock_settings):
     """Tests that the correct max_ttl is returned for a given key."""
     assert core.get_max_ttl_for_key("admin_key", mock_settings) == 3600
     assert core.get_max_ttl_for_key("user_key", mock_settings) == 600
 
+
 def test_get_max_ttl_for_nonexistent_key(mock_settings):
     """Tests that a non-existent key returns a max_ttl of 0."""
     assert core.get_max_ttl_for_key("fake_key", mock_settings) == 0
+
 
 def test_is_valid_api_key(mock_settings):
     """Tests that valid keys are recognized."""
     assert core.is_valid_api_key("admin_key", mock_settings) == True
     assert core.is_valid_api_key("user_key", mock_settings) == True
 
+
 def test_is_invalid_api_key(mock_settings):
     """Tests that an invalid key is rejected."""
     assert core.is_valid_api_key("fake_key", mock_settings) == False
 
+
 def test_duplicate_api_key_material_detected_across_plaintext_and_hash():
     """The same secret must be rejected even across key and key_hash forms."""
     with pytest.raises(ValueError, match="Duplicate API key material"):
-        core.APIKeyRegistry.from_settings([
-            {"key": "duplicate_key", "max_ttl": 3600, "allow_remote_whitelist": True},
-            {
-                "key_hash": core.hash_api_key("duplicate_key"),
-                "max_ttl": 600,
-                "allow_remote_whitelist": False,
-            },
-        ])
+        core.APIKeyRegistry.from_settings(
+            [
+                {"key": "duplicate_key", "max_ttl": 3600, "allow_remote_whitelist": True},
+                {
+                    "key_hash": core.hash_api_key("duplicate_key"),
+                    "max_ttl": 600,
+                    "allow_remote_whitelist": False,
+                },
+            ]
+        )
+
 
 def test_allow_remote_whitelist_must_be_boolean():
     with pytest.raises(ValueError, match="must define boolean allow_remote_whitelist"):
-        core.APIKeyRegistry.from_settings([
-            {"key": "admin_key", "max_ttl": 3600, "allow_remote_whitelist": "false"},
-        ])
+        core.APIKeyRegistry.from_settings(
+            [
+                {"key": "admin_key", "max_ttl": 3600, "allow_remote_whitelist": "false"},
+            ]
+        )
+
 
 def test_rate_limiter_reservation_can_be_released():
     """A released reservation should free the success slot immediately."""
-    limiter = core.SlidingWindowRateLimiter(window_seconds=60, successful_requests=1, failed_requests=1)
+    limiter = core.SlidingWindowRateLimiter(
+        window_seconds=60, successful_requests=1, failed_requests=1
+    )
 
     reservation = limiter.reserve("actor", "success", now=100)
 
@@ -148,13 +181,17 @@ def test_rate_limiter_reservation_can_be_released():
 
     assert limiter.reserve("actor", "success", now=100) is not None
 
+
 def test_rate_limiter_prunes_stale_actor_buckets():
-    limiter = core.SlidingWindowRateLimiter(window_seconds=10, successful_requests=1, failed_requests=1)
+    limiter = core.SlidingWindowRateLimiter(
+        window_seconds=10, successful_requests=1, failed_requests=1
+    )
 
     assert limiter.reserve("actor-a", "success", now=10) is not None
 
     assert limiter.can_allow("actor-b", "success", now=25) is True
     assert ("success", "actor-a") not in limiter._events
+
 
 def test_whitelist_store_contains_reloads_shared_state(tmp_path):
     whitelist_path = tmp_path / "whitelist.json"
@@ -167,6 +204,7 @@ def test_whitelist_store_contains_reloads_shared_state(tmp_path):
     core._write_whitelist_file(whitelist_path, {"203.0.113.10": now + 60})
 
     assert store.contains(address, now=now) is True
+
 
 def test_whitelist_store_contains_skips_reload_when_storage_unchanged(tmp_path, monkeypatch):
     whitelist_path = tmp_path / "whitelist.json"
@@ -211,6 +249,7 @@ def test_whitelist_store_compaction_preserves_entries_added_by_other_processes(t
 def test_api_key_helpers_propagate_configuration_errors(helper, expected_message):
     with pytest.raises(ValueError, match=expected_message):
         helper("any_key", {"api_keys": []})
+
 
 def test_ensure_runtime_state_is_initialized_once(tmp_path):
     settings = {

--- a/tests/test_firewalld.py
+++ b/tests/test_firewalld.py
@@ -9,8 +9,7 @@ This module tests all firewalld operations including:
 """
 
 import pytest
-import time
-from unittest.mock import Mock, patch, call
+from unittest.mock import patch, call
 from src import firewalld
 
 
@@ -26,12 +25,9 @@ def mock_settings():
             "monitored_ports": [
                 {"port": 80, "protocol": "tcp"},
                 {"port": 443, "protocol": "tcp"},
-                {"port": 22, "protocol": "tcp"}
+                {"port": 22, "protocol": "tcp"},
             ],
-            "monitored_ips": [
-                "0.0.0.0/0",
-                "::/0"
-            ]
+            "monitored_ips": ["0.0.0.0/0", "::/0"],
         }
     }
 
@@ -39,11 +35,7 @@ def mock_settings():
 @pytest.fixture
 def mock_settings_disabled():
     """Provides test settings with firewalld disabled."""
-    return {
-        "firewalld": {
-            "enabled": False
-        }
-    }
+    return {"firewalld": {"enabled": False}}
 
 
 @pytest.fixture
@@ -60,7 +52,7 @@ def firewalld_disabled(mock_settings_disabled):
 
 class TestFirewalldIntegrationInit:
     """Test initialization and configuration parsing."""
-    
+
     def test_initialization_with_full_config(self, firewalld_integration):
         """Test proper initialization with full configuration."""
         assert firewalld_integration.enabled is True
@@ -68,79 +60,74 @@ class TestFirewalldIntegrationInit:
         assert firewalld_integration.zone_priority == -100
         assert len(firewalld_integration.monitored_ports) == 3
         assert len(firewalld_integration.monitored_ips) == 2
-    
+
     def test_initialization_disabled(self, firewalld_disabled):
         """Test initialization when firewalld is disabled."""
         assert firewalld_disabled.enabled is False
         assert firewalld_disabled.zone_name == "knocker"  # Default value
-    
+
     def test_initialization_with_defaults(self):
         """Test initialization with minimal configuration (defaults)."""
         settings = {"firewalld": {"enabled": True}}
         integration = firewalld.FirewalldIntegration(settings)
-        
+
         assert integration.enabled is True
         assert integration.zone_name == "knocker"
         assert integration.zone_priority == -100
         assert integration.monitored_ports == []
         assert integration.monitored_ips == []
-    
+
     def test_is_enabled(self, firewalld_integration, firewalld_disabled):
         """Test is_enabled method."""
         assert firewalld_integration.is_enabled() is True
         assert firewalld_disabled.is_enabled() is False
-    
+
     def test_cidr_validation_success(self):
         """Test successful CIDR validation."""
         settings = {
             "firewalld": {
                 "enabled": True,
-                "monitored_ips": ["192.168.1.0/24", "10.0.0.0/8", "2001:db8::/32"]
+                "monitored_ips": ["192.168.1.0/24", "10.0.0.0/8", "2001:db8::/32"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.enabled is True
-    
+
     def test_cidr_validation_ipv4_missing_mask(self):
         """Test CIDR validation fails for IPv4 without mask."""
         settings = {
             "firewalld": {
                 "enabled": True,
-                "monitored_ips": ["192.168.1.1"]  # Missing /32
+                "monitored_ips": ["192.168.1.1"],  # Missing /32
             }
         }
         with pytest.raises(ValueError, match="explicit network mask"):
             firewalld.FirewalldIntegration(settings)
-    
+
     def test_cidr_validation_ipv6_missing_mask(self):
         """Test CIDR validation fails for IPv6 without mask."""
         settings = {
             "firewalld": {
                 "enabled": True,
-                "monitored_ips": ["2001:db8::1"]  # Missing /128
+                "monitored_ips": ["2001:db8::1"],  # Missing /128
             }
         }
         with pytest.raises(ValueError, match="explicit network mask"):
             firewalld.FirewalldIntegration(settings)
-    
+
     def test_cidr_validation_invalid_ip(self):
         """Test CIDR validation fails for invalid IP."""
-        settings = {
-            "firewalld": {
-                "enabled": True,
-                "monitored_ips": ["not.an.ip/24"]
-            }
-        }
+        settings = {"firewalld": {"enabled": True, "monitored_ips": ["not.an.ip/24"]}}
         with pytest.raises(ValueError, match="Invalid monitored IP configuration"):
             firewalld.FirewalldIntegration(settings)
-    
+
     def test_cidr_validation_disabled_skips_check(self):
         """Test CIDR validation is skipped when firewalld is disabled."""
         settings = {
             "firewalld": {
                 "enabled": False,
-                "monitored_ips": ["192.168.1.1"]  # Invalid but should be ignored
+                "monitored_ips": ["192.168.1.1"],  # Invalid but should be ignored
             }
         }
         # Should not raise exception when disabled
@@ -160,129 +147,119 @@ class TestFirewalldIntegrationInit:
 
         assert integration.enabled is False
         assert integration.zone_name == "test; rm -rf /"
-    
+
     def test_default_action_validation_drop(self):
         """Test default_action validation succeeds for 'drop'."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "default_action": "drop",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.default_action == "drop"
-    
+
     def test_default_action_validation_reject(self):
         """Test default_action validation succeeds for 'reject'."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "default_action": "reject",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.default_action == "reject"
-    
+
     def test_default_action_validation_invalid(self):
         """Test default_action validation fails for invalid action."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "default_action": "invalid",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         with pytest.raises(ValueError, match="Invalid default_action.*Must be 'drop' or 'reject'"):
             firewalld.FirewalldIntegration(settings)
-    
+
     def test_default_action_defaults_to_drop(self):
         """Test default_action defaults to 'drop' when not specified."""
-        settings = {
-            "firewalld": {
-                "enabled": True,
-                "monitored_ips": ["192.168.1.0/24"]
-            }
-        }
+        settings = {"firewalld": {"enabled": True, "monitored_ips": ["192.168.1.0/24"]}}
         # Should not raise exception and default to "drop"
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.default_action == "drop"
-    
+
     def test_zone_target_validation_default(self):
         """Test zone_target validation succeeds for 'default'."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "zone_target": "default",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.zone_target == "default"
-    
+
     def test_zone_target_validation_accept(self):
         """Test zone_target validation succeeds for 'ACCEPT'."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "zone_target": "ACCEPT",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.zone_target == "ACCEPT"
-    
+
     def test_zone_target_validation_reject(self):
         """Test zone_target validation succeeds for 'REJECT'."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "zone_target": "REJECT",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.zone_target == "REJECT"
-    
+
     def test_zone_target_validation_drop(self):
         """Test zone_target validation succeeds for 'DROP'."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "zone_target": "DROP",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         # Should not raise exception
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.zone_target == "DROP"
-    
+
     def test_zone_target_validation_invalid(self):
         """Test zone_target validation fails for invalid target."""
         settings = {
             "firewalld": {
                 "enabled": True,
                 "zone_target": "invalid",
-                "monitored_ips": ["192.168.1.0/24"]
+                "monitored_ips": ["192.168.1.0/24"],
             }
         }
         with pytest.raises(ValueError, match="Invalid zone_target.*Must be one of"):
             firewalld.FirewalldIntegration(settings)
-    
+
     def test_zone_target_not_set_by_default(self):
         """Test zone_target is None when not specified."""
-        settings = {
-            "firewalld": {
-                "enabled": True,
-                "monitored_ips": ["192.168.1.0/24"]
-            }
-        }
+        settings = {"firewalld": {"enabled": True, "monitored_ips": ["192.168.1.0/24"]}}
         # Should not raise exception and zone_target should be None
         integration = firewalld.FirewalldIntegration(settings)
         assert integration.zone_target is None
@@ -290,73 +267,75 @@ class TestFirewalldIntegrationInit:
 
 class TestFirewalldCommands:
     """Test firewall command execution."""
-    
-    @patch('subprocess.run')
+
+    @patch("subprocess.run")
     def test_run_firewall_cmd_success(self, mock_run, firewalld_integration):
         """Test successful firewall command execution."""
         mock_run.return_value.stdout = "success output"
         mock_run.return_value.stderr = ""
         mock_run.return_value.returncode = 0
-        
+
         success, stdout, stderr = firewalld_integration._run_firewall_cmd(["--state"])
-        
+
         assert success is True
         assert stdout == "success output"
         assert stderr == ""
         mock_run.assert_called_once()
-    
-    @patch('subprocess.run')
+
+    @patch("subprocess.run")
     def test_run_firewall_cmd_failure(self, mock_run, firewalld_integration):
         """Test failed firewall command execution."""
         from subprocess import CalledProcessError
+
         mock_run.side_effect = CalledProcessError(1, "firewall-cmd", stderr="error message")
-        
+
         success, stdout, stderr = firewalld_integration._run_firewall_cmd(["--invalid"])
-        
+
         assert success is False
         assert stderr == "error message"
-    
-    @patch('subprocess.run')
+
+    @patch("subprocess.run")
     def test_run_firewall_cmd_timeout(self, mock_run, firewalld_integration):
         """Test firewall command timeout."""
         from subprocess import TimeoutExpired
+
         mock_run.side_effect = TimeoutExpired("firewall-cmd", 30)
-        
+
         success, stdout, stderr = firewalld_integration._run_firewall_cmd(["--slow-command"])
-        
+
         assert success is False
         assert stderr == "Command timed out"
 
 
 class TestFirewalldAvailability:
     """Test firewalld availability checking."""
-    
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_is_firewalld_available_running(self, mock_cmd, firewalld_integration):
         """Test firewalld availability when running."""
         mock_cmd.return_value = (True, "running", "")
-        
+
         assert firewalld_integration.is_firewalld_available() is True
         mock_cmd.assert_called_once_with(["--state"], check=False)
-    
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_is_firewalld_available_not_running(self, mock_cmd, firewalld_integration):
         """Test firewalld availability when not running."""
         mock_cmd.return_value = (False, "", "not running")
-        
+
         assert firewalld_integration.is_firewalld_available() is False
 
 
 class TestFirewalldVersionCheck:
     """Test firewalld version compatibility checks on startup."""
 
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_check_version_ok(self, mock_cmd, firewalld_integration):
         """When firewall-cmd reports >= 2.0.0, the check should pass."""
         mock_cmd.return_value = (True, "firewall-cmd 2.3.1", "")
         assert firewalld_integration._check_firewalld_version() is True
 
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_check_version_too_old(self, mock_cmd, firewalld_integration, caplog):
         """When firewall-cmd reports < 2.0.0, the check should fail and log the error."""
         mock_cmd.return_value = (True, "firewall-cmd 1.9.8", "")
@@ -364,15 +343,16 @@ class TestFirewalldVersionCheck:
         assert firewalld_integration._check_firewalld_version() is False
         assert any("knocker requires Firewalld 2.0 or newer." in r.message for r in caplog.records)
 
+
 class TestZoneSetup:
     """Test knocker zone creation and setup."""
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_setup_zone_new_zone(self, mock_cmd, mock_available, firewalld_integration):
         """Test creating a new knocker zone."""
         mock_available.return_value = True
-        
+
         # Simulate zone doesn't exist, then successful creation
         # New behavior: adds DROP rules for each monitored port (3 ports) x 2 IP families = 6 rules
         mock_cmd.side_effect = [
@@ -387,20 +367,20 @@ class TestZoneSetup:
             (True, "", ""),  # DROP rule port 443 IPv6
             (True, "", ""),  # DROP rule port 22 IPv4
             (True, "", ""),  # DROP rule port 22 IPv6
-            (True, "", "")   # Reload
+            (True, "", ""),  # Reload
         ]
-        
+
         result = firewalld_integration.setup_knocker_zone()
-        
+
         assert result is True
         assert mock_cmd.call_count == 12
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_setup_zone_existing_zone(self, mock_cmd, mock_available, firewalld_integration):
         """Test setup with existing zone."""
         mock_available.return_value = True
-        
+
         # Zone exists, so skip creation but still add DROP rules
         mock_cmd.side_effect = [
             (True, "knocker-test zone info", ""),  # Zone exists
@@ -413,35 +393,35 @@ class TestZoneSetup:
             (True, "", ""),  # DROP rule port 443 IPv6
             (True, "", ""),  # DROP rule port 22 IPv4
             (True, "", ""),  # DROP rule port 22 IPv6
-            (True, "", "")   # Reload
+            (True, "", ""),  # Reload
         ]
-        
+
         result = firewalld_integration.setup_knocker_zone()
-        
+
         assert result is True
         assert mock_cmd.call_count == 11
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
     def test_setup_zone_firewalld_unavailable(self, mock_available, firewalld_integration):
         """Test zone setup when firewalld is unavailable."""
         mock_available.return_value = False
-        
+
         result = firewalld_integration.setup_knocker_zone()
-        
+
         assert result is False
-    
+
     def test_setup_zone_disabled(self, firewalld_disabled):
         """Test zone setup when firewalld is disabled."""
         result = firewalld_disabled.setup_knocker_zone()
-        
+
         assert result is True  # Returns True when disabled (no-op)
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_setup_zone_with_zone_target(self, mock_cmd, mock_available):
         """Test zone setup with zone_target configuration."""
         mock_available.return_value = True
-        
+
         # Create settings with zone_target
         settings = {
             "firewalld": {
@@ -450,14 +430,12 @@ class TestZoneSetup:
                 "zone_priority": -100,
                 "zone_target": "DROP",
                 "default_action": "drop",
-                "monitored_ports": [
-                    {"port": 80, "protocol": "tcp"}
-                ],
-                "monitored_ips": ["0.0.0.0/0"]
+                "monitored_ports": [{"port": 80, "protocol": "tcp"}],
+                "monitored_ips": ["0.0.0.0/0"],
             }
         }
         integration = firewalld.FirewalldIntegration(settings)
-        
+
         # Simulate zone doesn't exist, then successful creation with zone_target
         mock_cmd.side_effect = [
             (False, "", "zone not found"),  # Zone check
@@ -467,27 +445,27 @@ class TestZoneSetup:
             (True, "", ""),  # Add source 1
             (True, "", ""),  # DROP rule port 80 IPv4
             (True, "", ""),  # DROP rule port 80 IPv6
-            (True, "", "")   # Reload
+            (True, "", ""),  # Reload
         ]
-        
+
         result = integration.setup_knocker_zone()
-        
+
         assert result is True
         # Should have 8 calls total (including set-target)
         assert mock_cmd.call_count == 8
-        
+
         # Verify that set-target was called
         calls = mock_cmd.call_args_list
         set_target_call = [call for call in calls if "--set-target=" in str(call)]
         assert len(set_target_call) == 1
         assert "--set-target=DROP" in str(set_target_call[0])
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_setup_zone_without_zone_target(self, mock_cmd, mock_available):
         """Test zone setup without zone_target (default behavior)."""
         mock_available.return_value = True
-        
+
         # Create settings without zone_target
         settings = {
             "firewalld": {
@@ -495,14 +473,12 @@ class TestZoneSetup:
                 "zone_name": "knocker-test",
                 "zone_priority": -100,
                 "default_action": "drop",
-                "monitored_ports": [
-                    {"port": 80, "protocol": "tcp"}
-                ],
-                "monitored_ips": ["0.0.0.0/0"]
+                "monitored_ports": [{"port": 80, "protocol": "tcp"}],
+                "monitored_ips": ["0.0.0.0/0"],
             }
         }
         integration = firewalld.FirewalldIntegration(settings)
-        
+
         # Simulate zone doesn't exist, then successful creation without zone_target
         mock_cmd.side_effect = [
             (False, "", "zone not found"),  # Zone check
@@ -511,15 +487,15 @@ class TestZoneSetup:
             (True, "", ""),  # Add source 1
             (True, "", ""),  # DROP rule port 80 IPv4
             (True, "", ""),  # DROP rule port 80 IPv6
-            (True, "", "")   # Reload
+            (True, "", ""),  # Reload
         ]
-        
+
         result = integration.setup_knocker_zone()
-        
+
         assert result is True
         # Should have 7 calls total (no set-target)
         assert mock_cmd.call_count == 7
-        
+
         # Verify that set-target was NOT called
         calls = mock_cmd.call_args_list
         set_target_calls = [call for call in calls if "--set-target=" in str(call)]
@@ -528,61 +504,85 @@ class TestZoneSetup:
 
 class TestWhitelistRules:
     """Test adding and removing whitelist rules."""
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
-    @patch('time.time')
-    def test_add_whitelist_rule_success(self, mock_time, mock_cmd, mock_available, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
+    @patch("time.time")
+    def test_add_whitelist_rule_success(
+        self, mock_time, mock_cmd, mock_available, firewalld_integration
+    ):
         """Test successful addition of whitelist rules."""
         mock_available.return_value = True
         mock_time.return_value = 1000
-        
+
         # Success for all three monitored ports
         mock_cmd.side_effect = [
             (True, "", ""),  # Port 80
             (True, "", ""),  # Port 443
-            (True, "", "")   # Port 22
+            (True, "", ""),  # Port 22
         ]
-        
+
         result = firewalld_integration.add_whitelist_rule("192.168.1.100", 1600)
-        
+
         assert result is True
         assert mock_cmd.call_count == 3
-        
+
         # Verify rich rule format
         expected_calls = [
-            call(['--zone=knocker-test', '--add-rich-rule=rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="80" accept priority="1000"', '--timeout=600']),
-            call(['--zone=knocker-test', '--add-rich-rule=rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="443" accept priority="1000"', '--timeout=600']),
-            call(['--zone=knocker-test', '--add-rich-rule=rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="22" accept priority="1000"', '--timeout=600'])
+            call(
+                [
+                    "--zone=knocker-test",
+                    '--add-rich-rule=rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="80" accept priority="1000"',
+                    "--timeout=600",
+                ]
+            ),
+            call(
+                [
+                    "--zone=knocker-test",
+                    '--add-rich-rule=rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="443" accept priority="1000"',
+                    "--timeout=600",
+                ]
+            ),
+            call(
+                [
+                    "--zone=knocker-test",
+                    '--add-rich-rule=rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="22" accept priority="1000"',
+                    "--timeout=600",
+                ]
+            ),
         ]
         mock_cmd.assert_has_calls(expected_calls)
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
-    @patch('time.time')
-    def test_add_whitelist_rule_partial_failure(self, mock_time, mock_cmd, mock_available, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
+    @patch("time.time")
+    def test_add_whitelist_rule_partial_failure(
+        self, mock_time, mock_cmd, mock_available, firewalld_integration
+    ):
         """Test partial failure when adding whitelist rules."""
         mock_available.return_value = True
         mock_time.return_value = 1000
-        
+
         # Failure for one port, success for others, plus rollback calls
         mock_cmd.side_effect = [
-            (True, "", ""),   # Port 80 success
+            (True, "", ""),  # Port 80 success
             (False, "", "error"),  # Port 443 failure
-            (True, "", ""),   # Port 22 success
-            (True, "", ""),   # Rollback Port 80 success
-            (True, "", "")    # Rollback Port 22 success
+            (True, "", ""),  # Port 22 success
+            (True, "", ""),  # Rollback Port 80 success
+            (True, "", ""),  # Rollback Port 22 success
         ]
-        
+
         result = firewalld_integration.add_whitelist_rule("192.168.1.100", 1600)
-        
+
         assert result is False  # Should fail if not all rules added
         assert mock_cmd.call_count == 5  # 3 adds + 2 rollbacks
 
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
-    @patch('time.time')
-    def test_add_whitelist_rule_replace_on_already_enabled(self, mock_time, mock_cmd, mock_available, firewalld_integration):
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
+    @patch("time.time")
+    def test_add_whitelist_rule_replace_on_already_enabled(
+        self, mock_time, mock_cmd, mock_available, firewalld_integration
+    ):
         """When firewall-cmd reports the rule is already enabled, ensure we remove and re-add to update TTL."""
         mock_available.return_value = True
         mock_time.return_value = 1000
@@ -612,182 +612,186 @@ class TestWhitelistRules:
         called_args = [call_arg[0][0] for call_arg in mock_cmd.call_args_list]
         remove_found = any("--remove-rich-rule=" in " ".join(c) for c in called_args)
         assert remove_found is True
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
     def test_add_whitelist_rule_firewalld_unavailable(self, mock_available, firewalld_integration):
         """Test adding whitelist rule when firewalld is unavailable."""
         mock_available.return_value = False
-        
+
         result = firewalld_integration.add_whitelist_rule("192.168.1.100", 1600)
-        
+
         assert result is False
-    
+
     def test_add_whitelist_rule_disabled(self, firewalld_disabled):
         """Test adding whitelist rule when firewalld is disabled."""
         result = firewalld_disabled.add_whitelist_rule("192.168.1.100", 1600)
-        
+
         assert result is True  # Returns True when disabled (no-op)
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_remove_whitelist_rule_success(self, mock_cmd, mock_available, firewalld_integration):
         """Test successful removal of whitelist rules."""
         mock_available.return_value = True
-        
+
         # Success for all three monitored ports
         mock_cmd.side_effect = [
             (True, "", ""),  # Port 80
             (True, "", ""),  # Port 443
-            (True, "", "")   # Port 22
+            (True, "", ""),  # Port 22
         ]
-        
+
         result = firewalld_integration.remove_whitelist_rule("192.168.1.100")
-        
+
         assert result is True
         assert mock_cmd.call_count == 3
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_remove_whitelist_rule_not_found(self, mock_cmd, mock_available, firewalld_integration):
         """Test removing rules that don't exist (should not fail)."""
         mock_available.return_value = True
-        
+
         # All removals fail (rules not found)
         mock_cmd.side_effect = [
             (False, "", "not found"),  # Port 80
             (False, "", "not found"),  # Port 443
-            (False, "", "not found")   # Port 22
+            (False, "", "not found"),  # Port 22
         ]
-        
+
         result = firewalld_integration.remove_whitelist_rule("192.168.1.100")
-        
+
         assert result is True  # Should still return True (rules may have expired)
 
 
 class TestRuleRecovery:
     """Test startup rule recovery functionality."""
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_get_active_rules(self, mock_cmd, mock_available, firewalld_integration):
         """Test getting active firewalld rules."""
         mock_available.return_value = True
-        
+
         # Mock rich rules output
-        rich_rules_output = '''rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="80" accept
+        rich_rules_output = """rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="80" accept
 rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="443" accept
-rule family="ipv4" source address="10.0.0.50" port protocol="tcp" port="22" accept'''
-        
+rule family="ipv4" source address="10.0.0.50" port protocol="tcp" port="22" accept"""
+
         mock_cmd.return_value = (True, rich_rules_output, "")
-        
+
         rules = firewalld_integration.get_active_rules()
-        
+
         assert len(rules) == 3
         assert rules[0].ip_address == "192.168.1.100"
         assert rules[0].port == 80
         assert rules[0].protocol == "tcp"
         assert rules[1].port == 443
         assert rules[2].ip_address == "10.0.0.50"
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
     def test_get_active_rules_empty(self, mock_cmd, mock_available, firewalld_integration):
         """Test getting active rules when none exist."""
         mock_available.return_value = True
         mock_cmd.return_value = (True, "", "")
-        
+
         rules = firewalld_integration.get_active_rules()
-        
+
         assert len(rules) == 0
-    
-    @patch.object(firewalld.FirewalldIntegration, 'get_active_rules')
-    @patch.object(firewalld.FirewalldIntegration, '_add_single_rule')
-    @patch('time.time')
-    def test_restore_missing_rules_success(self, mock_time, mock_add_rule, mock_get_rules, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "get_active_rules")
+    @patch.object(firewalld.FirewalldIntegration, "_add_single_rule")
+    @patch("time.time")
+    def test_restore_missing_rules_success(
+        self, mock_time, mock_add_rule, mock_get_rules, firewalld_integration
+    ):
         """Test successful restoration of missing rules."""
         mock_time.return_value = 1000
-        
+
         # Whitelist has two IPs, but only one has active rules
         whitelist = {
             "192.168.1.100": 2000,  # Valid, expires in future
             "192.168.1.101": 2000,  # Valid, but missing from firewalld
-            "192.168.1.102": 500    # Expired, should be ignored
+            "192.168.1.102": 500,  # Expired, should be ignored
         }
-        
+
         # Mock active rules for only first IP and port 80
         active_rules = [
             firewalld.FirewalldRule("192.168.1.100", 80, "tcp", 2000),
             firewalld.FirewalldRule("192.168.1.100", 443, "tcp", 2000),
-            firewalld.FirewalldRule("192.168.1.100", 22, "tcp", 2000)
+            firewalld.FirewalldRule("192.168.1.100", 22, "tcp", 2000),
         ]
         mock_get_rules.return_value = active_rules
-        
+
         # Mock successful rule addition
         mock_add_rule.return_value = True
-        
+
         result = firewalld_integration.restore_missing_rules(whitelist)
-        
+
         assert result is True
         # Should restore 3 rules for the missing IP (192.168.1.101)
         assert mock_add_rule.call_count == 3
-    
-    @patch.object(firewalld.FirewalldIntegration, 'get_active_rules')
-    @patch.object(firewalld.FirewalldIntegration, '_add_single_rule')
-    @patch('time.time')
-    def test_restore_missing_rules_no_missing(self, mock_time, mock_add_rule, mock_get_rules, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "get_active_rules")
+    @patch.object(firewalld.FirewalldIntegration, "_add_single_rule")
+    @patch("time.time")
+    def test_restore_missing_rules_no_missing(
+        self, mock_time, mock_add_rule, mock_get_rules, firewalld_integration
+    ):
         """Test restoration when no rules are missing."""
         mock_time.return_value = 1000
-        
+
         # Whitelist matches active rules exactly
-        whitelist = {
-            "192.168.1.100": 2000
-        }
-        
+        whitelist = {"192.168.1.100": 2000}
+
         # Mock complete active rules
         active_rules = [
             firewalld.FirewalldRule("192.168.1.100", 80, "tcp", 2000),
             firewalld.FirewalldRule("192.168.1.100", 443, "tcp", 2000),
-            firewalld.FirewalldRule("192.168.1.100", 22, "tcp", 2000)
+            firewalld.FirewalldRule("192.168.1.100", 22, "tcp", 2000),
         ]
         mock_get_rules.return_value = active_rules
-        
+
         result = firewalld_integration.restore_missing_rules(whitelist)
-        
+
         assert result is True
         assert mock_add_rule.call_count == 0  # No rules to restore
-    
+
     def test_restore_missing_rules_disabled(self, firewalld_disabled):
         """Test restoration when firewalld is disabled."""
         result = firewalld_disabled.restore_missing_rules({"192.168.1.100": 2000})
-        
+
         assert result is True  # Returns True when disabled (no-op)
-    
-    @patch.object(firewalld.FirewalldIntegration, 'get_active_rules')
-    @patch('time.time')
-    def test_restore_missing_rules_replace_on_already_enabled(self, mock_time, mock_get_rules, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "get_active_rules")
+    @patch("time.time")
+    def test_restore_missing_rules_replace_on_already_enabled(
+        self, mock_time, mock_get_rules, firewalld_integration
+    ):
         """If adding a rule during restoration returns ALREADY_ENABLED, ensure knocker removes and re-adds it."""
         mock_time.return_value = 1000
-        
+
         # Whitelist contains one IP that is missing from active rules
         whitelist = {"192.168.1.200": 2000}
         mock_get_rules.return_value = []
-        
+
         # Simulate for each monitored port: add-warning, remove success, re-add success
         warning = (True, "", "Warning: ALREADY_ENABLED: 'rule' already in 'knocker'")
         remove = (True, "", "")
         readd = (True, "", "")
-        
+
         # For 3 monitored ports, expect (add-warning, remove, re-add) each
         side_effects = []
         for _ in range(3):
             side_effects.extend([warning, remove, readd])
-        
+
         # Patch the underlying _run_firewall_cmd used by _add_single_rule
-        with patch.object(firewalld_integration, '_run_firewall_cmd') as mock_cmd:
+        with patch.object(firewalld_integration, "_run_firewall_cmd") as mock_cmd:
             mock_cmd.side_effect = side_effects
-            
+
             result = firewalld_integration.restore_missing_rules(whitelist)
-            
+
             assert result is True
             # Expect 9 calls (3 ports * (add+remove+readd))
             assert mock_cmd.call_count == 9
@@ -795,44 +799,44 @@ rule family="ipv4" source address="10.0.0.50" port protocol="tcp" port="22" acce
 
 class TestRichRuleBuilder:
     """Test the _build_rich_rule helper function."""
-    
+
     def test_build_rich_rule_ipv4_single_host(self, firewalld_integration):
         """Test building rich rule for IPv4 single host."""
         rule = firewalld_integration._build_rich_rule("192.168.1.100", 80, "tcp")
         expected = 'rule family="ipv4" source address="192.168.1.100" port protocol="tcp" port="80" accept priority="1000"'
         assert rule == expected
-    
+
     def test_build_rich_rule_ipv4_cidr(self, firewalld_integration):
         """Test building rich rule for IPv4 CIDR."""
         rule = firewalld_integration._build_rich_rule("192.168.1.0/24", 443, "tcp")
         expected = 'rule family="ipv4" source address="192.168.1.0/24" port protocol="tcp" port="443" accept priority="1000"'
         assert rule == expected
-    
+
     def test_build_rich_rule_ipv6_single_host(self, firewalld_integration):
         """Test building rich rule for IPv6 single host."""
         rule = firewalld_integration._build_rich_rule("2001:db8::1", 22, "tcp")
         expected = 'rule family="ipv6" source address="2001:db8::1" port protocol="tcp" port="22" accept priority="1000"'
         assert rule == expected
-    
+
     def test_build_rich_rule_ipv6_cidr(self, firewalld_integration):
         """Test building rich rule for IPv6 CIDR."""
         rule = firewalld_integration._build_rich_rule("2001:db8::/32", 8080, "udp")
         expected = 'rule family="ipv6" source address="2001:db8::/32" port protocol="udp" port="8080" accept priority="1000"'
         assert rule == expected
-    
+
     def test_build_rich_rule_invalid_ip(self, firewalld_integration):
         """Test building rich rule with invalid IP address."""
         rule = firewalld_integration._build_rich_rule("not.an.ip", 80, "tcp")
         assert rule is None
-    
+
     def test_build_rich_rule_invalid_port(self, firewalld_integration):
         """Test building rich rule with invalid port."""
         rule = firewalld_integration._build_rich_rule("192.168.1.100", 70000, "tcp")
         assert rule is None
-        
+
         rule = firewalld_integration._build_rich_rule("192.168.1.100", 0, "tcp")
         assert rule is None
-    
+
     def test_build_rich_rule_invalid_protocol(self, firewalld_integration):
         """Test building rich rule with invalid protocol."""
         rule = firewalld_integration._build_rich_rule("192.168.1.100", 80, "invalid")
@@ -841,42 +845,44 @@ class TestRichRuleBuilder:
 
 class TestEdgeCases:
     """Test edge cases and error conditions."""
-    
+
     def test_firewalld_rule_str_representation(self):
         """Test string representation of FirewalldRule."""
         rule = firewalld.FirewalldRule("192.168.1.100", 80, "tcp", 1600)
         expected = "192.168.1.100:80/tcp (expires: 1600)"
-        
+
         assert str(rule) == expected
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
-    def test_get_active_rules_malformed_output(self, mock_cmd, mock_available, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
+    def test_get_active_rules_malformed_output(
+        self, mock_cmd, mock_available, firewalld_integration
+    ):
         """Test parsing malformed rich rules output."""
         mock_available.return_value = True
-        
+
         # Malformed rich rules output
-        malformed_output = '''rule family="ipv4" source address="192.168.1.100" INVALID
+        malformed_output = """rule family="ipv4" source address="192.168.1.100" INVALID
 invalid line
-rule family="ipv4" source address="10.0.0.1" port protocol="tcp" port="invalid_port" accept'''
-        
+rule family="ipv4" source address="10.0.0.1" port protocol="tcp" port="invalid_port" accept"""
+
         mock_cmd.return_value = (True, malformed_output, "")
-        
+
         rules = firewalld_integration.get_active_rules()
-        
+
         # Should handle malformed lines gracefully
         assert len(rules) == 0  # No valid rules parsed
-    
-    @patch('time.time')
+
+    @patch("time.time")
     def test_add_single_rule_calculation(self, mock_time, firewalld_integration):
         """Test timeout calculation in _add_single_rule."""
         mock_time.return_value = 1000
-        
-        with patch.object(firewalld_integration, '_run_firewall_cmd') as mock_cmd:
+
+        with patch.object(firewalld_integration, "_run_firewall_cmd") as mock_cmd:
             mock_cmd.return_value = (True, "", "")
-            
+
             firewalld_integration._add_single_rule("192.168.1.100", 80, "tcp", 600)
-            
+
             # Verify timeout parameter
             call_args = mock_cmd.call_args[0][0]
             assert "--timeout=600" in call_args
@@ -884,65 +890,67 @@ rule family="ipv4" source address="10.0.0.1" port protocol="tcp" port="invalid_p
 
 class TestGlobalFunctions:
     """Test module-level functions."""
-    
+
     def test_initialize_firewalld(self, mock_settings):
         """Test global firewalld initialization."""
         integration = firewalld.initialize_firewalld(mock_settings)
-        
+
         assert integration is not None
         assert integration.enabled is True
         assert firewalld.get_firewalld_integration() is integration
-    
+
     def test_get_firewalld_integration_none(self):
         """Test getting firewalld integration when not initialized."""
         firewalld.firewalld_integration = None
-        
+
         result = firewalld.get_firewalld_integration()
-        
+
         assert result is None
 
 
 class TestSecurityAndValidation:
     """Test security considerations and input validation."""
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
-    @patch('time.time')
-    def test_ip_injection_protection(self, mock_time, mock_cmd, mock_available, firewalld_integration):
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
+    @patch("time.time")
+    def test_ip_injection_protection(
+        self, mock_time, mock_cmd, mock_available, firewalld_integration
+    ):
         """Test that malicious IP addresses are properly rejected."""
         mock_available.return_value = True
         mock_time.return_value = 1000
         mock_cmd.return_value = (True, "", "")
-        
+
         # Test with potentially malicious IP (command injection attempt)
         malicious_ip = "192.168.1.1; rm -rf /"
-        
+
         result = firewalld_integration.add_whitelist_rule(malicious_ip, 1600)
-        
+
         # Verify that the malicious IP is rejected (result should be False)
         assert result is False
-        
+
         # Verify that _run_firewall_cmd was never called due to input validation
         mock_cmd.assert_not_called()
-    
-    @patch.object(firewalld.FirewalldIntegration, 'is_firewalld_available')
-    @patch.object(firewalld.FirewalldIntegration, '_run_firewall_cmd')
-    @patch('time.time')
+
+    @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
+    @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
+    @patch("time.time")
     def test_zone_name_injection_protection(self, mock_time, mock_cmd, mock_available):
         """Invalid zone names should be rejected before subprocess execution."""
         mock_available.return_value = True
         mock_time.return_value = 1000
         mock_cmd.return_value = (True, "", "")
-        
+
         # Create integration with potentially malicious zone name
         malicious_settings = {
             "firewalld": {
                 "enabled": True,
                 "zone_name": "test; rm -rf /",
-                "monitored_ports": [{"port": 80, "protocol": "tcp"}]
+                "monitored_ports": [{"port": 80, "protocol": "tcp"}],
             }
         }
-        
+
         with pytest.raises(ValueError, match="Invalid zone_name"):
             firewalld.FirewalldIntegration(malicious_settings)
 

--- a/tests/test_firewalld.py
+++ b/tests/test_firewalld.py
@@ -356,6 +356,7 @@ class TestZoneSetup:
         # Simulate zone doesn't exist, then successful creation
         # New behavior: adds DROP rules for each monitored port (3 ports) x 2 IP families = 6 rules
         mock_cmd.side_effect = [
+            (True, "firewall-cmd 2.3.1", ""),  # Version check
             (False, "", "zone not found"),  # Zone check
             (True, "", ""),  # Create zone
             (True, "", ""),  # Set priority
@@ -373,7 +374,7 @@ class TestZoneSetup:
         result = firewalld_integration.setup_knocker_zone()
 
         assert result is True
-        assert mock_cmd.call_count == 12
+        assert mock_cmd.call_count == 13
 
     @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
     @patch.object(firewalld.FirewalldIntegration, "_run_firewall_cmd")
@@ -383,6 +384,7 @@ class TestZoneSetup:
 
         # Zone exists, so skip creation but still add DROP rules
         mock_cmd.side_effect = [
+            (True, "firewall-cmd 2.3.1", ""),  # Version check
             (True, "knocker-test zone info", ""),  # Zone exists
             (True, "", ""),  # Set priority
             (True, "", ""),  # Add source 1 (0.0.0.0/0)
@@ -399,7 +401,7 @@ class TestZoneSetup:
         result = firewalld_integration.setup_knocker_zone()
 
         assert result is True
-        assert mock_cmd.call_count == 11
+        assert mock_cmd.call_count == 12
 
     @patch.object(firewalld.FirewalldIntegration, "is_firewalld_available")
     def test_setup_zone_firewalld_unavailable(self, mock_available, firewalld_integration):
@@ -438,6 +440,7 @@ class TestZoneSetup:
 
         # Simulate zone doesn't exist, then successful creation with zone_target
         mock_cmd.side_effect = [
+            (True, "firewall-cmd 2.3.1", ""),  # Version check
             (False, "", "zone not found"),  # Zone check
             (True, "", ""),  # Create zone
             (True, "", ""),  # Set priority
@@ -451,8 +454,8 @@ class TestZoneSetup:
         result = integration.setup_knocker_zone()
 
         assert result is True
-        # Should have 8 calls total (including set-target)
-        assert mock_cmd.call_count == 8
+        # Should have 9 calls total including the version probe and set-target
+        assert mock_cmd.call_count == 9
 
         # Verify that set-target was called
         calls = mock_cmd.call_args_list
@@ -481,6 +484,7 @@ class TestZoneSetup:
 
         # Simulate zone doesn't exist, then successful creation without zone_target
         mock_cmd.side_effect = [
+            (True, "firewall-cmd 2.3.1", ""),  # Version check
             (False, "", "zone not found"),  # Zone check
             (True, "", ""),  # Create zone
             (True, "", ""),  # Set priority
@@ -493,8 +497,8 @@ class TestZoneSetup:
         result = integration.setup_knocker_zone()
 
         assert result is True
-        # Should have 7 calls total (no set-target)
-        assert mock_cmd.call_count == 7
+        # Should have 8 calls total including the version probe
+        assert mock_cmd.call_count == 8
 
         # Verify that set-target was NOT called
         calls = mock_cmd.call_args_list

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,13 +4,12 @@ from src.main import app, get_client_ip_dependency, get_settings
 
 # --- Test Fixtures ---
 
+
 @pytest.fixture
 def mock_settings():
     """Provides a standard settings object for API tests."""
     return {
-        "server": {
-            "trusted_proxies": ["127.0.0.1"]
-        },
+        "server": {"trusted_proxies": ["127.0.0.1"]},
         "api_keys": [
             {"key": "ADMIN_KEY", "max_ttl": 3600, "allow_remote_whitelist": True},
             {"key": "USER_KEY_1", "max_ttl": 600, "allow_remote_whitelist": False},
@@ -18,12 +17,11 @@ def mock_settings():
         "whitelist": {"storage_path": "./test_whitelist.json"},
         "security": {
             "always_allowed_ips": ["100.100.100.100", "2001:db8:cafe::/48"],
-            "excluded_paths": ["/healthz", "/api/v1/public"]
+            "excluded_paths": ["/healthz", "/api/v1/public"],
         },
-        "cors": {
-            "allowed_origin": "*"
-        }
+        "cors": {"allowed_origin": "*"},
     }
+
 
 @pytest.fixture(autouse=True)
 def override_settings(mock_settings):
@@ -36,10 +34,12 @@ def override_settings(mock_settings):
     # Clean up the override after the test is done
     app.dependency_overrides = {}
 
+
 @pytest.fixture(autouse=True)
 def cleanup_whitelist(mock_settings):
     """Ensure the test whitelist is clean before and after each test."""
     import os
+
     path = mock_settings["whitelist"]["storage_path"]
     if os.path.exists(path):
         os.remove(path)
@@ -47,44 +47,51 @@ def cleanup_whitelist(mock_settings):
     if os.path.exists(path):
         os.remove(path)
 
+
 client = TestClient(app)
 
 # --- Test /knock Endpoint ---
 
+
 def test_knock_success_source_ip_uses_default_ttl():
     """A valid key should be able to whitelist its own IP and use the default max_ttl."""
     response = client.post(
-        "/knock",
-        headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "1.2.3.4"}
+        "/knock", headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "1.2.3.4"}
     )
     assert response.status_code == 200
     data = response.json()
     assert data["whitelisted_entry"] == "1.2.3.4"
     assert data["expires_in_seconds"] == 600
 
+
 def test_knock_success_remote_ip_with_permission():
     """An admin key should be able to whitelist a remote IP."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ip_address": "2001:db8::/120"}
+        json={"ip_address": "2001:db8::/120"},
     )
     assert response.status_code == 200
     assert response.json()["whitelisted_entry"] == "2001:db8::/120"
+
 
 def test_knock_fail_remote_ip_without_permission():
     """A standard user key should NOT be able to whitelist a remote IP."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "1.2.3.4"},
-        json={"ip_address": "8.8.8.8"}
+        json={"ip_address": "8.8.8.8"},
     )
     assert response.status_code == 403
 
+
 def test_knock_fail_invalid_api_key():
     """A request with a bad API key should be rejected."""
-    response = client.post("/knock", headers={"X-Api-Key": "INVALID_KEY", "X-Forwarded-For": "1.2.3.4"})
+    response = client.post(
+        "/knock", headers={"X-Api-Key": "INVALID_KEY", "X-Forwarded-For": "1.2.3.4"}
+    )
     assert response.status_code == 401
+
 
 def test_knock_unresolved_client_ip_is_rate_limited(mock_settings):
     """Requests without a resolved client IP should eventually hit the failure limiter."""
@@ -105,52 +112,58 @@ def test_knock_unresolved_client_ip_is_rate_limited(mock_settings):
     assert second.status_code == 429
     assert second.json() == {"error": "Too many knock attempts."}
 
+
 def test_knock_fail_invalid_ip_in_body():
     """A request with a malformed IP in the body should be rejected."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ip_address": "not-an-ip"}
+        json={"ip_address": "not-an-ip"},
     )
     assert response.status_code == 400
+
 
 def test_knock_with_custom_valid_ttl():
     """A knock with a custom TTL lower than the max should be accepted."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ttl": 300}
+        json={"ttl": 300},
     )
     assert response.status_code == 200
     assert response.json()["expires_in_seconds"] == 300
+
 
 def test_knock_with_custom_ttl_exceeding_max():
     """A knock with a custom TTL higher than the max should be capped at the max."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "1.2.3.4"},
-        json={"ttl": 9999}
+        json={"ttl": 9999},
     )
     assert response.status_code == 200
-    assert response.json()["expires_in_seconds"] == 600 # Capped at the key's max_ttl
+    assert response.json()["expires_in_seconds"] == 600  # Capped at the key's max_ttl
+
 
 def test_knock_with_invalid_ttl_negative():
     """A knock with a negative TTL should be rejected."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ttl": -100}
+        json={"ttl": -100},
     )
     assert response.status_code == 400
+
 
 def test_knock_with_invalid_ttl_string():
     """A knock with a non-integer TTL should be rejected."""
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ttl": "three hundred"}
+        json={"ttl": "three hundred"},
     )
     assert response.status_code == 400
+
 
 def test_knock_options_cors():
     """OPTIONS request to /knock should return 204 with CORS headers."""
@@ -159,13 +172,13 @@ def test_knock_options_cors():
     assert response.headers["Access-Control-Allow-Origin"] == "*"
     assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
     allow_headers = {
-        header.strip()
-        for header in response.headers["Access-Control-Allow-Headers"].split(",")
+        header.strip() for header in response.headers["Access-Control-Allow-Headers"].split(",")
     }
     assert allow_headers == {
         "X-Api-Key",
         "Content-Type",
     }
+
 
 def test_knock_firewalld_exception_returns_json_error(monkeypatch):
     def fake_add(*args, **kwargs):
@@ -183,6 +196,7 @@ def test_knock_firewalld_exception_returns_json_error(monkeypatch):
         "error": "Internal server error: whitelist persistence or firewall configuration failed."
     }
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+
 
 def test_knock_success_rate_limit_is_atomic(monkeypatch, mock_settings):
     """Concurrent successes should not bypass the configured success limit."""
@@ -235,35 +249,40 @@ def test_knock_success_rate_limit_is_atomic(monkeypatch, mock_settings):
     assert second_response.status_code == 429
     assert call_count == 1
 
+
 def test_knock_post_cors_header():
     """POST /knock should include Access-Control-Allow-Origin header."""
     response = client.post(
-        "/knock",
-        headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "1.2.3.4"}
+        "/knock", headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "1.2.3.4"}
     )
     assert response.status_code == 200
     assert response.headers["Access-Control-Allow-Origin"] == "*"
 
+
 # --- Test /verify Endpoint ---
+
 
 def test_verify_success_whitelisted_ip():
     """A whitelisted IP should pass the /verify endpoint."""
     # First, knock to whitelist the IP
     client.post("/knock", headers={"X-Api-Key": "USER_KEY_1", "X-Forwarded-For": "5.6.7.8"})
-    
+
     # Then, verify it
     response = client.get("/verify", headers={"X-Forwarded-For": "5.6.7.8"})
     assert response.status_code == 200
+
 
 def test_verify_fail_non_whitelisted_ip():
     """A non-whitelisted IP should fail the /verify endpoint."""
     response = client.get("/verify", headers={"X-Forwarded-For": "9.10.11.12"})
     assert response.status_code == 401
 
+
 def test_verify_success_always_allowed_ip():
     """An IP in the always-allowed list should pass /verify without a knock."""
     response = client.get("/verify", headers={"X-Forwarded-For": "100.100.100.100"})
     assert response.status_code == 200
+
 
 def test_verify_success_always_allowed_cidr():
     """An IP within an always-allowed CIDR should pass /verify."""
@@ -285,12 +304,19 @@ def test_verify_rejects_malformed_forwarded_chain_from_trusted_proxy(mock_settin
 
     assert response.status_code == 401
 
+
 def test_verify_success_excluded_path():
     """A request to an excluded path should pass /verify regardless of IP."""
-    response = client.get("/verify", headers={"X-Forwarded-For": "9.9.9.9", "X-Forwarded-Uri": "/healthz"})
+    response = client.get(
+        "/verify", headers={"X-Forwarded-For": "9.9.9.9", "X-Forwarded-Uri": "/healthz"}
+    )
     assert response.status_code == 200
+
 
 def test_verify_success_excluded_path_prefix():
     """A request to a path that starts with an excluded prefix should pass."""
-    response = client.get("/verify", headers={"X-Forwarded-For": "9.9.9.9", "X-Forwarded-Uri": "/api/v1/public/status"})
+    response = client.get(
+        "/verify",
+        headers={"X-Forwarded-For": "9.9.9.9", "X-Forwarded-Uri": "/api/v1/public/status"},
+    )
     assert response.status_code == 200

--- a/tests/test_main_firewalld_integration.py
+++ b/tests/test_main_firewalld_integration.py
@@ -20,9 +20,10 @@ from src import core
 def create_temp_config_file(config_dict):
     """Create a temporary config file and return its path."""
     import yaml
-    fd, path = tempfile.mkstemp(suffix='.yaml', text=True)
+
+    fd, path = tempfile.mkstemp(suffix=".yaml", text=True)
     try:
-        with os.fdopen(fd, 'w') as f:
+        with os.fdopen(fd, "w") as f:
             yaml.dump(config_dict, f)
         return path
     except:
@@ -32,14 +33,14 @@ def create_temp_config_file(config_dict):
 
 class TestCoreFirewalldIntegrationFunction:
     """Test the core add_ip_to_whitelist_with_firewalld function."""
-    
+
     def setup_method(self):
         """Setup for each test."""
         # Clean up any existing whitelist file
         if os.path.exists("/tmp/test_whitelist.json"):
             os.remove("/tmp/test_whitelist.json")
-    
-    @patch('src.firewalld.get_firewalld_integration')
+
+    @patch("src.firewalld.get_firewalld_integration")
     def test_add_with_firewalld_success(self, mock_get_integration):
         """Test successful addition with firewalld enabled."""
         # Mock firewalld integration
@@ -47,24 +48,24 @@ class TestCoreFirewalldIntegrationFunction:
         mock_integration.is_enabled.return_value = True
         mock_integration.add_whitelist_rule.return_value = True
         mock_get_integration.return_value = mock_integration
-        
+
         settings = {"whitelist": {"storage_path": "/tmp/test_whitelist.json"}}
-        
+
         # Use a future timestamp
         future_time = int(time.time()) + 3600
         result = core.add_ip_to_whitelist_with_firewalld("192.168.1.100", future_time, settings)
-        
+
         assert result is True
-        
+
         # Verify firewalld was called
         mock_integration.add_whitelist_rule.assert_called_once_with("192.168.1.100", future_time)
-        
+
         # Verify whitelist.json was updated
         whitelist = core.load_whitelist(settings)
         assert "192.168.1.100" in whitelist
         assert whitelist["192.168.1.100"] == future_time
-    
-    @patch('src.firewalld.get_firewalld_integration')  
+
+    @patch("src.firewalld.get_firewalld_integration")
     def test_add_with_firewalld_failure(self, mock_get_integration):
         """Test addition failure when firewalld fails."""
         # Mock firewalld integration failure
@@ -72,96 +73,98 @@ class TestCoreFirewalldIntegrationFunction:
         mock_integration.is_enabled.return_value = True
         mock_integration.add_whitelist_rule.return_value = False  # Firewalld failed
         mock_get_integration.return_value = mock_integration
-        
+
         settings = {"whitelist": {"storage_path": "/tmp/test_whitelist.json"}}
-        
+
         # Use a future timestamp
         future_time = int(time.time()) + 3600
         result = core.add_ip_to_whitelist_with_firewalld("192.168.1.100", future_time, settings)
-        
+
         assert result is False
-        
+
         # Verify firewalld was called
         mock_integration.add_whitelist_rule.assert_called_once_with("192.168.1.100", future_time)
-        
+
         # Verify whitelist.json was NOT updated
         whitelist = core.load_whitelist(settings)
         assert "192.168.1.100" not in whitelist
-    
-    @patch('src.firewalld.get_firewalld_integration')
+
+    @patch("src.firewalld.get_firewalld_integration")
     def test_add_with_firewalld_disabled(self, mock_get_integration):
         """Test addition when firewalld is disabled."""
         # Mock disabled firewalld integration
         mock_integration = Mock()
         mock_integration.is_enabled.return_value = False
         mock_get_integration.return_value = mock_integration
-        
+
         settings = {"whitelist": {"storage_path": "/tmp/test_whitelist.json"}}
-        
+
         # Use a future timestamp
         future_time = int(time.time()) + 3600
         result = core.add_ip_to_whitelist_with_firewalld("192.168.1.100", future_time, settings)
-        
+
         assert result is True
-        
+
         # Verify firewalld add_whitelist_rule was NOT called (since disabled)
         mock_integration.add_whitelist_rule.assert_not_called()
-        
+
         # Verify whitelist.json was still updated
         whitelist = core.load_whitelist(settings)
         assert "192.168.1.100" in whitelist
-    
-    @patch('src.firewalld.get_firewalld_integration')
+
+    @patch("src.firewalld.get_firewalld_integration")
     def test_add_with_no_firewalld_integration(self, mock_get_integration):
         """Test addition when firewalld integration is not available."""
         # Mock no firewalld integration
         mock_get_integration.return_value = None
-        
+
         settings = {"whitelist": {"storage_path": "/tmp/test_whitelist.json"}}
-        
+
         # Use a future timestamp
         future_time = int(time.time()) + 3600
         result = core.add_ip_to_whitelist_with_firewalld("192.168.1.100", future_time, settings)
-        
+
         assert result is True
-        
+
         # Verify whitelist.json was updated (fallback behavior)
         whitelist = core.load_whitelist(settings)
         assert "192.168.1.100" in whitelist
 
-    @patch('src.firewalld.get_firewalld_integration')
+    @patch("src.firewalld.get_firewalld_integration")
     def test_add_with_firewalld_rollback_on_whitelist_failure(self, mock_get_integration):
         """Test rollback when whitelist.json update fails."""
-        with patch('src.core.add_ip_to_whitelist') as mock_add_whitelist:
+        with patch("src.core.add_ip_to_whitelist") as mock_add_whitelist:
             # Mock firewalld integration success
             mock_integration = Mock()
             mock_integration.is_enabled.return_value = True
             mock_integration.add_whitelist_rule.return_value = True
             mock_integration.remove_whitelist_rule.return_value = True
             mock_get_integration.return_value = mock_integration
-            
+
             # Mock whitelist.json update failure
             mock_add_whitelist.side_effect = Exception("Disk full")
-            
+
             settings = {"whitelist": {"storage_path": "/tmp/test_whitelist.json"}}
-            
+
             # Use a future timestamp
             future_time = int(time.time()) + 3600
             result = core.add_ip_to_whitelist_with_firewalld("192.168.1.100", future_time, settings)
-            
+
             assert result is False
-            
+
             # Verify firewalld rules were added then rolled back
-            mock_integration.add_whitelist_rule.assert_called_once_with("192.168.1.100", future_time)
+            mock_integration.add_whitelist_rule.assert_called_once_with(
+                "192.168.1.100", future_time
+            )
             mock_integration.remove_whitelist_rule.assert_called_once_with("192.168.1.100")
-            
+
             # Verify whitelist.json update was attempted
             mock_add_whitelist.assert_called_once()
 
 
 class TestEndpointFirewalldIntegration:
     """Test endpoint integration with firewalld using simpler approach."""
-    
+
     def test_knock_endpoint_firewalld_success(self):
         """Test knock endpoint calls firewalld integration correctly."""
         # Create config with firewalld enabled
@@ -170,17 +173,21 @@ class TestEndpointFirewalldIntegration:
             "cors": {"allowed_origin": "*"},
             "whitelist": {"storage_path": "/tmp/test_whitelist.json"},
             "api_keys": [{"key": "test_key", "max_ttl": 3600, "allow_remote_whitelist": False}],
-            "firewalld": {"enabled": True, "zone_name": "test", "monitored_ports": [{"port": 80, "protocol": "tcp"}]}
+            "firewalld": {
+                "enabled": True,
+                "zone_name": "test",
+                "monitored_ports": [{"port": 80, "protocol": "tcp"}],
+            },
         }
-        
+
         config_path = create_temp_config_file(config_dict)
-        
+
         try:
             # Set environment variable for config
             os.environ["KNOCKER_CONFIG_PATH"] = config_path
-            
+
             # Import and patch firewalld after setting config
-            with patch('src.firewalld.FirewalldIntegration') as mock_firewalld_class:
+            with patch("src.firewalld.FirewalldIntegration") as mock_firewalld_class:
                 # Mock the FirewalldIntegration class
                 mock_integration = Mock()
                 mock_integration.is_enabled.return_value = True
@@ -190,29 +197,26 @@ class TestEndpointFirewalldIntegration:
                 mock_integration.restore_missing_rules.return_value = True
                 mock_integration.add_whitelist_rule.return_value = True
                 mock_firewalld_class.return_value = mock_integration
-                
+
                 # Mock the global instance
                 import src.firewalld as firewalld_module
+
                 firewalld_module.firewalld_integration = mock_integration
-                
+
                 from src import main
-                
+
                 # Create test client
                 client = TestClient(main.app)
-                
+
                 # Test successful knock
                 response = client.post(
-                    "/knock",
-                    headers={
-                        "X-Api-Key": "test_key",
-                        "X-Forwarded-For": "192.168.1.100"
-                    }
+                    "/knock", headers={"X-Api-Key": "test_key", "X-Forwarded-For": "192.168.1.100"}
                 )
-                
+
                 assert response.status_code == 200
                 data = response.json()
                 assert data["whitelisted_entry"] == "192.168.1.100"
-                
+
         finally:
             # Cleanup
             if "KNOCKER_CONFIG_PATH" in os.environ:
@@ -221,7 +225,7 @@ class TestEndpointFirewalldIntegration:
                 os.unlink(config_path)
             if os.path.exists("/tmp/test_whitelist.json"):
                 os.unlink("/tmp/test_whitelist.json")
-    
+
     def test_knock_endpoint_firewalld_disabled(self):
         """Test knock endpoint when firewalld is disabled."""
         config_dict = {
@@ -229,42 +233,39 @@ class TestEndpointFirewalldIntegration:
             "cors": {"allowed_origin": "*"},
             "whitelist": {"storage_path": "/tmp/test_whitelist.json"},
             "api_keys": [{"key": "test_key", "max_ttl": 3600, "allow_remote_whitelist": False}],
-            "firewalld": {"enabled": False}
+            "firewalld": {"enabled": False},
         }
-        
+
         config_path = create_temp_config_file(config_dict)
-        
+
         try:
             os.environ["KNOCKER_CONFIG_PATH"] = config_path
-            
-            with patch('src.firewalld.FirewalldIntegration') as mock_firewalld_class:
+
+            with patch("src.firewalld.FirewalldIntegration") as mock_firewalld_class:
                 # Mock disabled firewalld integration
                 mock_integration = Mock()
                 mock_integration.is_enabled.return_value = False
                 # Provide compatible version check stub even if disabled (harmless)
                 mock_integration._check_firewalld_version.return_value = True
                 mock_firewalld_class.return_value = mock_integration
-                
+
                 import src.firewalld as firewalld_module
+
                 firewalld_module.firewalld_integration = mock_integration
-                
+
                 from src import main
-                
+
                 client = TestClient(main.app)
-                
+
                 # Test successful knock with firewalld disabled
                 response = client.post(
-                    "/knock",
-                    headers={
-                        "X-Api-Key": "test_key",
-                        "X-Forwarded-For": "192.168.1.100"
-                    }
+                    "/knock", headers={"X-Api-Key": "test_key", "X-Forwarded-For": "192.168.1.100"}
                 )
-                
+
                 assert response.status_code == 200
                 data = response.json()
                 assert data["whitelisted_entry"] == "192.168.1.100"
-                
+
         finally:
             if "KNOCKER_CONFIG_PATH" in os.environ:
                 del os.environ["KNOCKER_CONFIG_PATH"]

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,15 +1,14 @@
 """
 Tests for OpenAPI documentation generation and functionality.
 """
+
 import asyncio
 import copy
-import json
 import os
-import tempfile
 import pytest
 from pathlib import Path
 from fastapi.testclient import TestClient
-from main import app, get_settings, generate_and_persist_openapi
+from src.main import app, get_settings, generate_and_persist_openapi
 
 
 def configure_app_with_settings(settings: dict):
@@ -24,9 +23,7 @@ def configure_app_with_settings(settings: dict):
 def mock_settings():
     """Provides a standard settings object for API tests."""
     return {
-        "server": {
-            "trusted_proxies": ["127.0.0.1"]
-        },
+        "server": {"trusted_proxies": ["127.0.0.1"]},
         "api_keys": [
             {"key": "ADMIN_KEY", "max_ttl": 3600, "allow_remote_whitelist": True},
             {"key": "USER_KEY_1", "max_ttl": 600, "allow_remote_whitelist": False},
@@ -34,15 +31,10 @@ def mock_settings():
         "whitelist": {"storage_path": "./test_whitelist.json"},
         "security": {
             "always_allowed_ips": ["100.100.100.100", "2001:db8:cafe::/48"],
-            "excluded_paths": ["/healthz", "/api/v1/public"]
+            "excluded_paths": ["/healthz", "/api/v1/public"],
         },
-        "cors": {
-            "allowed_origin": "*"
-        },
-        "documentation": {
-            "enabled": True,
-            "openapi_output_path": "test_openapi.json"
-        }
+        "cors": {"allowed_origin": "*"},
+        "documentation": {"enabled": True, "openapi_output_path": "test_openapi.json"},
     }
 
 
@@ -55,7 +47,9 @@ def override_settings(mock_settings):
     cleanup_settings = {
         "documentation": {
             "enabled": False,
-            "openapi_output_path": settings_copy.get("documentation", {}).get("openapi_output_path", "openapi.json")
+            "openapi_output_path": settings_copy.get("documentation", {}).get(
+                "openapi_output_path", "openapi.json"
+            ),
         }
     }
     asyncio.run(generate_and_persist_openapi(app, copy.deepcopy(cleanup_settings)))
@@ -64,7 +58,6 @@ def override_settings(mock_settings):
 @pytest.fixture(autouse=True)
 def cleanup_test_files():
     """Clean up test files."""
-    import os
     files_to_clean = ["./test_whitelist.json", "openapi.json", "test_openapi.json"]
     for file in files_to_clean:
         if os.path.exists(file):
@@ -85,7 +78,7 @@ def test_openapi_json_endpoint(client):
     """Test that the OpenAPI JSON endpoint is accessible."""
     response = client.get("/openapi.json")
     assert response.status_code == 200
-    
+
     schema = response.json()
     assert schema["openapi"] == "3.1.0"
     assert schema["info"]["title"] == "Knocker API"
@@ -111,18 +104,18 @@ def test_openapi_schema_structure(client):
     """Test that the OpenAPI schema has proper structure."""
     response = client.get("/openapi.json")
     schema = response.json()
-    
+
     # Check basic structure
     assert "paths" in schema
     assert "components" in schema
     assert "info" in schema
-    
+
     # Check endpoint paths
     paths = schema["paths"]
     assert "/knock" in paths
     assert "/health" in paths
     assert "/verify" in paths
-    
+
     # Check that POST /knock has proper structure
     knock_post = paths["/knock"]["post"]
     assert "tags" in knock_post
@@ -130,7 +123,7 @@ def test_openapi_schema_structure(client):
     assert "summary" in knock_post
     assert "description" in knock_post
     assert "responses" in knock_post
-    
+
     # Check response schemas
     responses = knock_post["responses"]
     assert "200" in responses
@@ -144,23 +137,23 @@ def test_pydantic_models_in_schema(client):
     """Test that Pydantic models are properly included in schema."""
     response = client.get("/openapi.json")
     schema = response.json()
-    
+
     components = schema.get("components", {})
     schemas = components.get("schemas", {})
-    
+
     # Check that our custom models are present
     assert "KnockRequest" in schemas
     assert "KnockResponse" in schemas
     assert "HealthResponse" in schemas
     assert "ErrorResponse" in schemas
-    
+
     # Check KnockRequest structure
     knock_request = schemas["KnockRequest"]
     assert "properties" in knock_request
     properties = knock_request["properties"]
     assert "ip_address" in properties
     assert "ttl" in properties
-    
+
     # Check KnockResponse structure
     knock_response = schemas["KnockResponse"]
     assert "properties" in knock_response
@@ -174,20 +167,20 @@ def test_endpoint_tags_and_descriptions(client):
     """Test that endpoints have proper tags and descriptions."""
     response = client.get("/openapi.json")
     schema = response.json()
-    
+
     paths = schema["paths"]
-    
+
     # Test /knock POST endpoint
     knock_post = paths["/knock"]["post"]
     assert knock_post["tags"] == ["Authentication"]
     assert "Whitelist IP Address" in knock_post["summary"]
     assert "API key" in knock_post["description"]
-    
+
     # Test /health endpoint
     health_get = paths["/health"]["get"]
     assert health_get["tags"] == ["System"]
     assert "Health Check" in health_get["summary"]
-    
+
     # Test /verify endpoint
     verify_get = paths["/verify"]["get"]
     assert verify_get["tags"] == ["Authentication"]
@@ -198,18 +191,18 @@ def test_api_tags_configuration(client):
     """Test that OpenAPI tags are properly configured."""
     response = client.get("/openapi.json")
     schema = response.json()
-    
+
     tags = schema.get("tags", [])
     tag_names = [tag["name"] for tag in tags]
-    
+
     assert "Authentication" in tag_names
     assert "System" in tag_names
-    
+
     # Check tag descriptions
     auth_tag = next(tag for tag in tags if tag["name"] == "Authentication")
     assert "whitelisting" in auth_tag["description"].lower()
-    
-    system_tag = next(tag for tag in tags if tag["name"] == "System")  
+
+    system_tag = next(tag for tag in tags if tag["name"] == "System")
     assert "health" in system_tag["description"].lower()
 
 
@@ -219,10 +212,10 @@ def test_backward_compatibility_with_dict_input(client):
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ip_address": "192.168.1.100", "ttl": 3600}
+        json={"ip_address": "192.168.1.100", "ttl": 3600},
     )
     assert response.status_code == 200
-    
+
     data = response.json()
     assert "whitelisted_entry" in data
     assert "expires_at" in data
@@ -235,10 +228,10 @@ def test_validation_error_conversion(client):
     response = client.post(
         "/knock",
         headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-        json={"ttl": -100}
+        json={"ttl": -100},
     )
     assert response.status_code == 400
-    
+
     data = response.json()
     assert "error" in data
     assert "TTL" in data["error"]
@@ -247,17 +240,17 @@ def test_validation_error_conversion(client):
 def test_documentation_endpoints_available_when_enabled(client):
     """Test that documentation endpoints are available when documentation is enabled."""
     # The default mock_settings has documentation.enabled = True
-    
+
     # Test that documentation endpoints work
     docs_response = client.get("/docs")
-    redoc_response = client.get("/redoc") 
+    redoc_response = client.get("/redoc")
     openapi_response = client.get("/openapi.json")
-    
+
     # All should work when documentation is enabled
     assert docs_response.status_code == 200
     assert redoc_response.status_code == 200
     assert openapi_response.status_code == 200
-    
+
     # Verify content types are appropriate
     assert "text/html" in docs_response.headers.get("content-type", "")
     assert "text/html" in redoc_response.headers.get("content-type", "")
@@ -267,22 +260,20 @@ def test_documentation_endpoints_available_when_enabled(client):
 def test_app_configuration_honors_documentation_settings(tmp_path):
     """Test that the app correctly applies documentation settings."""
     schema_path = tmp_path / "config_openapi.json"
-    
-    enabled_settings = {
-        "documentation": {"enabled": True, "openapi_output_path": str(schema_path)}
-    }
+
+    enabled_settings = {"documentation": {"enabled": True, "openapi_output_path": str(schema_path)}}
     asyncio.run(generate_and_persist_openapi(app, enabled_settings))
-    
+
     assert app.docs_url == "/docs"
     assert app.redoc_url == "/redoc"
     assert app.openapi_url == "/openapi.json"
     assert schema_path.exists()
-    
+
     disabled_settings = {
         "documentation": {"enabled": False, "openapi_output_path": str(schema_path)}
     }
     asyncio.run(generate_and_persist_openapi(app, disabled_settings))
-    
+
     assert app.docs_url is None
     assert app.redoc_url is None
     assert app.openapi_url is None
@@ -292,14 +283,14 @@ def test_documentation_disabled_removes_endpoints_and_schema(tmp_path, mock_sett
     """Documentation disabled removes routes and deletes persisted schema."""
     schema_path = tmp_path / "disabled_openapi.json"
     schema_path.write_text("{}")
-    
+
     disabled_settings = copy.deepcopy(mock_settings)
     disabled_settings["documentation"]["enabled"] = False
     disabled_settings["documentation"]["openapi_output_path"] = str(schema_path)
-    
+
     configure_app_with_settings(disabled_settings)
     local_client = TestClient(app)
-    
+
     assert local_client.get("/docs").status_code == 404
     assert local_client.get("/redoc").status_code == 404
     assert local_client.get("/openapi.json").status_code == 404
@@ -310,13 +301,13 @@ def test_documentation_defaults_to_disabled_when_missing(mock_settings):
     """Missing documentation config defaults to disabled behaviour."""
     default_schema_path = Path("openapi.json")
     default_schema_path.write_text("{}")
-    
+
     missing_settings = copy.deepcopy(mock_settings)
     missing_settings.pop("documentation", None)
-    
+
     configure_app_with_settings(missing_settings)
     local_client = TestClient(app)
-    
+
     assert local_client.get("/docs").status_code == 404
     assert local_client.get("/redoc").status_code == 404
     assert local_client.get("/openapi.json").status_code == 404
@@ -326,21 +317,21 @@ def test_documentation_defaults_to_disabled_when_missing(mock_settings):
 def test_documentation_can_be_reenabled_after_disable(tmp_path, mock_settings):
     """Disabling, then re-enabling documentation restores routes and schema."""
     schema_path = tmp_path / "reenabled_openapi.json"
-    
+
     disabled_settings = copy.deepcopy(mock_settings)
     disabled_settings["documentation"]["enabled"] = False
     disabled_settings["documentation"]["openapi_output_path"] = str(schema_path)
     configure_app_with_settings(disabled_settings)
     disabled_client = TestClient(app)
-    
+
     assert disabled_client.get("/docs").status_code == 404
     assert not schema_path.exists()
-    
+
     enabled_settings = copy.deepcopy(mock_settings)
     enabled_settings["documentation"]["openapi_output_path"] = str(schema_path)
     configure_app_with_settings(enabled_settings)
     enabled_client = TestClient(app)
-    
+
     assert enabled_client.get("/docs").status_code == 200
     assert enabled_client.get("/redoc").status_code == 200
     assert enabled_client.get("/openapi.json").status_code == 200

--- a/tests/test_production_hardening.py
+++ b/tests/test_production_hardening.py
@@ -2,6 +2,7 @@
 Tests for production hardening improvements.
 Tests timing attack resistance, edge case handling, and input validation.
 """
+
 import pytest
 import time
 from pathlib import Path
@@ -14,20 +15,28 @@ from src import core
 def test_settings():
     """Test settings with multiple API keys."""
     return {
-        "server": {
-            "trusted_proxies": ["127.0.0.1", "172.29.238.0/24"]
-        },
+        "server": {"trusted_proxies": ["127.0.0.1", "172.29.238.0/24"]},
         "api_keys": [
-            {"key": "valid_key_12345", "max_ttl": 3600, "allow_remote_whitelist": True, "name": "test1"},
-            {"key": "another_valid_key", "max_ttl": 600, "allow_remote_whitelist": False, "name": "test2"},
+            {
+                "key": "valid_key_12345",
+                "max_ttl": 3600,
+                "allow_remote_whitelist": True,
+                "name": "test1",
+            },
+            {
+                "key": "another_valid_key",
+                "max_ttl": 600,
+                "allow_remote_whitelist": False,
+                "name": "test2",
+            },
         ],
         "whitelist": {"storage_path": "./test_prod_whitelist.json"},
         "security": {
             "always_allowed_ips": ["192.168.1.100"],
             "excluded_paths": ["/health"],
-            "max_whitelist_entries": 100
+            "max_whitelist_entries": 100,
         },
-        "cors": {"allowed_origin": "https://example.com"}
+        "cors": {"allowed_origin": "https://example.com"},
     }
 
 
@@ -43,6 +52,7 @@ def override_settings(test_settings):
 def cleanup_whitelist(test_settings):
     """Clean up test whitelist files."""
     import os
+
     path = test_settings["whitelist"]["storage_path"]
     if os.path.exists(path):
         os.remove(path)
@@ -63,36 +73,36 @@ class TestTimingAttackResistance:
 
         assert "--no-proxy-headers" in content
         assert "--forwarded-allow-ips" not in content
-    
+
     def test_constant_time_validation(self, test_settings):
         """
         Verify timing is consistent regardless of key validity using robust statistical analysis.
-        
+
         Uses warm-up runs, large sample size, outlier removal, and statistical testing
         to detect timing attack vulnerabilities.
         """
         valid_key = "valid_key_12345"
         invalid_key = "invalid_key_12345"
-        
+
         # Warm-up runs to stabilize timing
         for _ in range(10):
             core.is_valid_api_key(valid_key, test_settings)
             core.is_valid_api_key(invalid_key, test_settings)
-        
+
         # Collect measurements with high-resolution timing
         sample_size = 150
         valid_times = []
         invalid_times = []
-        
+
         for _ in range(sample_size):
             start = time.perf_counter_ns()
             core.is_valid_api_key(valid_key, test_settings)
             valid_times.append(time.perf_counter_ns() - start)
-            
+
             start = time.perf_counter_ns()
             core.is_valid_api_key(invalid_key, test_settings)
             invalid_times.append(time.perf_counter_ns() - start)
-        
+
         # Remove outliers using trimmed mean (remove top/bottom 10%)
         def trimmed_mean(samples, trim_percent=0.1):
             sorted_samples = sorted(samples)
@@ -102,18 +112,18 @@ class TestTimingAttackResistance:
             else:
                 trimmed = sorted_samples
             return sum(trimmed) / len(trimmed), trimmed
-        
+
         valid_mean, valid_trimmed = trimmed_mean(valid_times)
         invalid_mean, invalid_trimmed = trimmed_mean(invalid_times)
-        
+
         # Calculate standard deviations
         def std_dev(samples, mean):
             variance = sum((x - mean) ** 2 for x in samples) / len(samples)
-            return variance ** 0.5
-        
+            return variance**0.5
+
         valid_std = std_dev(valid_trimmed, valid_mean)
         invalid_std = std_dev(invalid_trimmed, invalid_mean)
-        
+
         # Perform Mann-Whitney U test (non-parametric)
         # Null hypothesis: distributions are the same
         def mann_whitney_u(samples1, samples2):
@@ -121,55 +131,56 @@ class TestTimingAttackResistance:
             n1, n2 = len(samples1), len(samples2)
             combined = [(val, 0) for val in samples1] + [(val, 1) for val in samples2]
             combined.sort(key=lambda x: x[0])
-            
+
             # Calculate ranks
             rank_sum_1 = sum(i + 1 for i, (val, group) in enumerate(combined) if group == 0)
-            
+
             # Calculate U statistic
             u1 = rank_sum_1 - (n1 * (n1 + 1)) / 2
             u2 = n1 * n2 - u1
             u = min(u1, u2)
-            
+
             # Calculate expected value and standard deviation under null hypothesis
             mean_u = n1 * n2 / 2
             std_u = ((n1 * n2 * (n1 + n2 + 1)) / 12) ** 0.5
-            
+
             # Calculate z-score
             z = (u - mean_u) / std_u if std_u > 0 else 0
-            
+
             # For two-tailed test, we want |z| to be small (distributions similar)
             # p-value approximation: larger |z| means more different distributions
             return abs(z)
-        
+
         z_score = mann_whitney_u(valid_trimmed, invalid_trimmed)
-        
+
         # Check relative difference (must be < 10% for practical constant-time)
         relative_diff = abs(valid_mean - invalid_mean) / max(valid_mean, invalid_mean)
-        
+
         # For timing attack resistance, we care about practical exploitability.
         # Over a network, timing differences < 10% at nanosecond scale are not exploitable
         # due to network jitter, OS scheduling, and other noise sources.
         # This test validates the implementation follows constant-time principles.
         assert relative_diff < 0.10, (
-            f"Timing difference too large: {relative_diff*100:.1f}% difference between "
+            f"Timing difference too large: {relative_diff * 100:.1f}% difference between "
             f"valid ({valid_mean:.0f}ns ± {valid_std:.0f}ns) and "
             f"invalid ({invalid_mean:.0f}ns ± {invalid_std:.0f}ns) key validation times. "
             f"This indicates a structural timing difference in the implementation."
         )
-        
+
         # Log timing stats for informational purposes
         import logging
+
         logging.info(
             f"Timing attack test: valid={valid_mean:.0f}ns ± {valid_std:.0f}ns, "
             f"invalid={invalid_mean:.0f}ns ± {invalid_std:.0f}ns, "
-            f"diff={relative_diff*100:.2f}%, z-score={z_score:.2f}"
+            f"diff={relative_diff * 100:.2f}%, z-score={z_score:.2f}"
         )
-    
+
     def test_empty_api_key_handled(self, test_settings):
         """Empty API key should be handled gracefully."""
         assert core.is_valid_api_key("", test_settings) == False
         assert core.is_valid_api_key(None, test_settings) == False
-    
+
     def test_empty_api_keys_list_raises_configuration_error(self):
         """Empty API keys list should surface a configuration error."""
         settings = {"api_keys": []}
@@ -179,111 +190,111 @@ class TestTimingAttackResistance:
 
 class TestTTLEdgeCases:
     """Test TTL validation edge cases."""
-    
+
     def test_zero_ttl_rejected(self):
         """TTL of 0 should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ttl": 0}
+            json={"ttl": 0},
         )
         assert response.status_code == 400
         assert "positive integer" in response.json()["error"].lower()
-    
+
     def test_negative_ttl_rejected(self):
         """Negative TTL should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ttl": -100}
+            json={"ttl": -100},
         )
         assert response.status_code == 400
         assert "positive integer" in response.json()["error"].lower()
-    
+
     def test_extremely_large_ttl_rejected(self):
         """Extremely large TTL (>10 years) should be rejected."""
         ten_years = 315360000
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ttl": ten_years + 1}
+            json={"ttl": ten_years + 1},
         )
         assert response.status_code == 400
         assert "too large" in response.json()["error"].lower()
-    
+
     def test_max_valid_ttl_accepted(self):
         """Maximum valid TTL (10 years) should be accepted but capped by key limit."""
         ten_years = 315360000
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ttl": ten_years}
+            json={"ttl": ten_years},
         )
         assert response.status_code == 200
         # Should be capped to key's max_ttl (3600)
         assert response.json()["expires_in_seconds"] == 3600
-    
+
     def test_float_ttl_rejected(self):
         """Float TTL should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ttl": 3.14}
+            json={"ttl": 3.14},
         )
         assert response.status_code == 400
-    
+
     def test_string_ttl_rejected(self):
         """String TTL should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ttl": "3600"}
+            json={"ttl": "3600"},
         )
         assert response.status_code == 400
 
 
 class TestInputSizeValidation:
     """Test input size limits to prevent DoS."""
-    
+
     def test_extremely_long_ip_rejected(self):
         """IP address longer than 100 chars should be rejected."""
         long_ip = "1.2.3.4" + "x" * 100
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": long_ip}
+            json={"ip_address": long_ip},
         )
         assert response.status_code == 400
         assert "too long" in response.json()["error"].lower()
-    
+
     def test_non_string_ip_rejected(self):
         """Non-string IP should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": 12345}
+            json={"ip_address": 12345},
         )
         assert response.status_code == 400
-    
+
     def test_valid_ipv6_length_accepted(self):
         """Valid IPv6 with CIDR should be accepted."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
+            json={"ip_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"},
         )
         assert response.status_code == 200
 
 
 class TestHealthCheckDependencies:
     """Test that health check validates critical dependencies."""
-    
+
     def test_health_check_with_valid_config(self):
         """Health check should pass with valid configuration."""
         response = client.get("/health")
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
-    
+
     def test_health_check_detects_missing_api_keys(self):
         """Health check should fail if no API keys are configured."""
         bad_settings = {
@@ -291,13 +302,13 @@ class TestHealthCheckDependencies:
             "whitelist": {"storage_path": "./test_health_whitelist.json"},
         }
         app.dependency_overrides[get_settings] = lambda: bad_settings
-        
+
         response = client.get("/health")
         assert response.status_code == 503
         assert "unhealthy" in response.json()["status"]
-        
+
         app.dependency_overrides = {}
-    
+
     def test_health_check_detects_storage_issues(self, test_settings, monkeypatch):
         """Health check should detect inaccessible storage."""
         bad_settings = {**test_settings, "whitelist": {"storage_path": "./will_fail.json"}}
@@ -311,17 +322,18 @@ class TestHealthCheckDependencies:
         assert resp.status_code == 503
         app.dependency_overrides = {}
 
+
 class TestConfigurationValidation:
     """Test configuration loading validation."""
-    
+
     def test_duplicate_api_keys_detected(self, tmp_path):
         """Duplicate API keys should be detected during config load."""
         import os
         from src import config
-        
+
         # Save original env var
         original_path = os.environ.get("KNOCKER_CONFIG_PATH")
-        
+
         try:
             # Create a config with duplicate keys
             config_content = """
@@ -337,14 +349,14 @@ api_keys:
 """
             config_file = tmp_path / "test_config.yaml"
             config_file.write_text(config_content)
-            
+
             # Set environment variable
             os.environ["KNOCKER_CONFIG_PATH"] = str(config_file)
-            
+
             # Should exit with error
             with pytest.raises(SystemExit) as exc_info:
                 config.load_config()
-            
+
             assert exc_info.value.code == 1
         finally:
             # Restore original env var
@@ -352,47 +364,47 @@ api_keys:
                 os.environ["KNOCKER_CONFIG_PATH"] = original_path
             elif "KNOCKER_CONFIG_PATH" in os.environ:
                 del os.environ["KNOCKER_CONFIG_PATH"]
-    
+
     def test_empty_api_keys_detected(self, tmp_path):
         """Empty API keys list should be detected."""
         import os
         from src import config
-        
+
         original_path = os.environ.get("KNOCKER_CONFIG_PATH")
-        
+
         try:
             config_content = """
 api_keys: []
 """
             config_file = tmp_path / "test_config.yaml"
             config_file.write_text(config_content)
-            
+
             os.environ["KNOCKER_CONFIG_PATH"] = str(config_file)
-            
+
             with pytest.raises(SystemExit) as exc_info:
                 config.load_config()
-            
+
             assert exc_info.value.code == 1
         finally:
             if original_path:
                 os.environ["KNOCKER_CONFIG_PATH"] = original_path
             elif "KNOCKER_CONFIG_PATH" in os.environ:
                 del os.environ["KNOCKER_CONFIG_PATH"]
-    
+
     def test_path_traversal_in_config_path_rejected(self, tmp_path):
         """Path traversal in KNOCKER_CONFIG_PATH should be rejected."""
         import os
         from src import config
-        
+
         original_path = os.environ.get("KNOCKER_CONFIG_PATH")
-        
+
         try:
             # Try to use path traversal
             os.environ["KNOCKER_CONFIG_PATH"] = "../../../etc/passwd"
-            
+
             with pytest.raises(SystemExit) as exc_info:
                 config.load_config()
-            
+
             assert exc_info.value.code == 1
         finally:
             if original_path:
@@ -403,86 +415,80 @@ api_keys: []
 
 class TestAPIKeyValidation:
     """Test comprehensive API key validation."""
-    
+
     def test_missing_api_key_rejected(self):
         """Request without API key should be rejected."""
-        response = client.post(
-            "/knock",
-            headers={"X-Forwarded-For": "1.2.3.4"},
-            json={}
-        )
+        response = client.post("/knock", headers={"X-Forwarded-For": "1.2.3.4"}, json={})
         assert response.status_code == 401
-    
+
     def test_invalid_api_key_rejected(self):
         """Request with invalid API key should be rejected."""
         response = client.post(
-            "/knock",
-            headers={"X-Api-Key": "invalid_key", "X-Forwarded-For": "1.2.3.4"},
-            json={}
+            "/knock", headers={"X-Api-Key": "invalid_key", "X-Forwarded-For": "1.2.3.4"}, json={}
         )
         assert response.status_code == 401
-    
+
     def test_valid_api_key_accepted(self):
         """Request with valid API key should be accepted."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-            json={}
+            json={},
         )
         assert response.status_code == 200
 
 
 class TestEdgeCaseHandling:
     """Test various edge cases in the application."""
-    
+
     def test_concurrent_requests_handled(self):
         """Multiple concurrent requests should be handled safely."""
         import threading
-        
+
         results = []
-        
+
         def make_request():
             response = client.post(
                 "/knock",
                 headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"},
-                json={}
+                json={},
             )
             results.append(response.status_code)
-        
+
         threads = [threading.Thread(target=make_request) for _ in range(10)]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
-        
+
         # All requests should succeed
         assert all(code == 200 for code in results)
-    
+
     def test_malformed_json_rejected(self, test_settings):
         """Malformed JSON should be rejected gracefully."""
         import os
+
         # Ensure KNOCKER_CONFIG_PATH is set to a valid path for this test
         # since previous tests may have changed it
         test_config_path = os.path.abspath("knocker.example.yaml")
         if os.path.exists(test_config_path):
             os.environ["KNOCKER_CONFIG_PATH"] = test_config_path
-        
+
         response = client.post(
             "/knock",
             headers={
                 "X-Api-Key": "valid_key_12345",
                 "X-Forwarded-For": "1.2.3.4",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
-            content="{ invalid json }"
+            content="{ invalid json }",
         )
         assert response.status_code == 422 or response.status_code == 400
-    
+
     def test_empty_request_body_accepted(self):
         """Empty request body should be accepted (whitelist client IP)."""
         response = client.post(
-            "/knock",
-            headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"}
+            "/knock", headers={"X-Api-Key": "valid_key_12345", "X-Forwarded-For": "1.2.3.4"}
         )
         assert response.status_code == 200
         assert response.json()["whitelisted_entry"] == "1.2.3.4"

--- a/tests/test_production_hardening.py
+++ b/tests/test_production_hardening.py
@@ -5,10 +5,44 @@ Tests timing attack resistance, edge case handling, and input validation.
 
 import pytest
 import time
+import logging
 from pathlib import Path
 from fastapi.testclient import TestClient
 from src.main import app, get_settings
 from src import core
+
+
+def _minimal_valid_config_yaml() -> str:
+    return """
+server:
+  host: "0.0.0.0"
+  port: 8000
+  trusted_proxies:
+    - "127.0.0.1"
+cors:
+  allowed_origin: "https://example.com"
+security:
+  always_allowed_ips: []
+  excluded_paths:
+    - "/knock"
+  max_whitelist_entries: 100
+whitelist:
+  storage_path: "/tmp/knocker-test-whitelist.json"
+  cleanup_interval_seconds: 60
+api_keys:
+  - name: "primary"
+    key: "secret-1"
+    max_ttl: 3600
+    allow_remote_whitelist: true
+documentation:
+  enabled: false
+""".strip()
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    config_file = tmp_path / "test_config.yaml"
+    config_file.write_text(content)
+    return config_file
 
 
 @pytest.fixture
@@ -326,7 +360,7 @@ class TestHealthCheckDependencies:
 class TestConfigurationValidation:
     """Test configuration loading validation."""
 
-    def test_duplicate_api_keys_detected(self, tmp_path):
+    def test_duplicate_api_keys_detected(self, tmp_path, caplog):
         """Duplicate API keys should be detected during config load."""
         import os
         from src import config
@@ -335,29 +369,25 @@ class TestConfigurationValidation:
         original_path = os.environ.get("KNOCKER_CONFIG_PATH")
 
         try:
-            # Create a config with duplicate keys
-            config_content = """
-api_keys:
-  - name: "key1"
-    key: "duplicate_key"
-    max_ttl: 3600
-    allow_remote_whitelist: true
-  - name: "key2"
-    key: "duplicate_key"
-    max_ttl: 600
-    allow_remote_whitelist: false
-"""
-            config_file = tmp_path / "test_config.yaml"
-            config_file.write_text(config_content)
+            config_file = _write_config(
+                tmp_path,
+                _minimal_valid_config_yaml().replace(
+                    "allow_remote_whitelist: true",
+                    'allow_remote_whitelist: true\n  - name: "duplicate"\n    key: "secret-1"\n    max_ttl: 600\n    allow_remote_whitelist: false',
+                    1,
+                ),
+            )
 
             # Set environment variable
             os.environ["KNOCKER_CONFIG_PATH"] = str(config_file)
 
             # Should exit with error
+            caplog.set_level(logging.CRITICAL)
             with pytest.raises(SystemExit) as exc_info:
                 config.load_config()
 
             assert exc_info.value.code == 1
+            assert "Duplicate API key material detected at index 1" in caplog.text
         finally:
             # Restore original env var
             if original_path:
@@ -365,7 +395,7 @@ api_keys:
             elif "KNOCKER_CONFIG_PATH" in os.environ:
                 del os.environ["KNOCKER_CONFIG_PATH"]
 
-    def test_empty_api_keys_detected(self, tmp_path):
+    def test_empty_api_keys_detected(self, tmp_path, caplog):
         """Empty API keys list should be detected."""
         import os
         from src import config
@@ -373,25 +403,27 @@ api_keys:
         original_path = os.environ.get("KNOCKER_CONFIG_PATH")
 
         try:
-            config_content = """
-api_keys: []
-"""
-            config_file = tmp_path / "test_config.yaml"
-            config_file.write_text(config_content)
+            config_content = _minimal_valid_config_yaml().replace(
+                'api_keys:\n  - name: "primary"\n    key: "secret-1"\n    max_ttl: 3600\n    allow_remote_whitelist: true',
+                "api_keys: []",
+            )
+            config_file = _write_config(tmp_path, config_content)
 
             os.environ["KNOCKER_CONFIG_PATH"] = str(config_file)
 
+            caplog.set_level(logging.CRITICAL)
             with pytest.raises(SystemExit) as exc_info:
                 config.load_config()
 
             assert exc_info.value.code == 1
+            assert "Configuration must contain at least one API key" in caplog.text
         finally:
             if original_path:
                 os.environ["KNOCKER_CONFIG_PATH"] = original_path
             elif "KNOCKER_CONFIG_PATH" in os.environ:
                 del os.environ["KNOCKER_CONFIG_PATH"]
 
-    def test_path_traversal_in_config_path_rejected(self, tmp_path):
+    def test_path_traversal_in_config_path_rejected(self, tmp_path, caplog):
         """Path traversal in KNOCKER_CONFIG_PATH should be rejected."""
         import os
         from src import config
@@ -399,13 +431,17 @@ api_keys: []
         original_path = os.environ.get("KNOCKER_CONFIG_PATH")
 
         try:
+            _write_config(tmp_path, _minimal_valid_config_yaml())
+
             # Try to use path traversal
             os.environ["KNOCKER_CONFIG_PATH"] = "../../../etc/passwd"
 
+            caplog.set_level(logging.CRITICAL)
             with pytest.raises(SystemExit) as exc_info:
                 config.load_config()
 
             assert exc_info.value.code == 1
+            assert "Invalid configuration path: ../../../etc/passwd" in caplog.text
         finally:
             if original_path:
                 os.environ["KNOCKER_CONFIG_PATH"] = original_path
@@ -464,7 +500,7 @@ class TestEdgeCaseHandling:
         # All requests should succeed
         assert all(code == 200 for code in results)
 
-    def test_malformed_json_rejected(self, test_settings):
+    def test_malformed_json_rejected(self, test_settings, monkeypatch):
         """Malformed JSON should be rejected gracefully."""
         import os
 
@@ -472,7 +508,7 @@ class TestEdgeCaseHandling:
         # since previous tests may have changed it
         test_config_path = os.path.abspath("knocker.example.yaml")
         if os.path.exists(test_config_path):
-            os.environ["KNOCKER_CONFIG_PATH"] = test_config_path
+            monkeypatch.setenv("KNOCKER_CONFIG_PATH", test_config_path)
 
         response = client.post(
             "/knock",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -263,8 +263,11 @@ class TestRaceConditions:
         for thread in threads:
             thread.join()
 
-        # Check whitelist integrity - all entries should be present
-        # This test doesn't assert failure but demonstrates the race condition risk
+        whitelist = core.load_whitelist(app.dependency_overrides[get_settings]())
+        expected_ips = {f"10.0.0.{i}" for i in range(10)}
+
+        assert set(whitelist) == expected_ips
+        assert len(whitelist) == 10
 
 
 class TestDenialOfService:
@@ -334,7 +337,7 @@ class TestDenialOfService:
                     # If file was created, clean it up and fail the test
                     try:
                         os.remove(dangerous_path)
-                    except:
+                    except FileNotFoundError:
                         pass
                     assert False, f"Dangerous file was created at {dangerous_path}"
             except (PermissionError, OSError, FileNotFoundError, NotADirectoryError, ValueError):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,6 +3,7 @@ Security tests for Caddy Knocker.
 These tests verify that security vulnerabilities have been properly fixed.
 Tests pass when attacks are successfully blocked.
 """
+
 import pytest
 import time
 import logging
@@ -15,9 +16,7 @@ from src import core
 def security_test_settings():
     """Settings configuration for security tests."""
     return {
-        "server": {
-            "trusted_proxies": ["172.29.238.0/24", "127.0.0.1"]
-        },
+        "server": {"trusted_proxies": ["172.29.238.0/24", "127.0.0.1"]},
         "api_keys": [
             {"key": "ADMIN_KEY", "max_ttl": 3600, "allow_remote_whitelist": True, "name": "admin"},
             {"key": "USER_KEY", "max_ttl": 600, "allow_remote_whitelist": False, "name": "user"},
@@ -25,9 +24,9 @@ def security_test_settings():
         "whitelist": {"storage_path": "./test_security_whitelist.json"},
         "security": {
             "always_allowed_ips": ["192.168.1.100"],
-            "excluded_paths": ["/api/status", "/healthz"]
+            "excluded_paths": ["/api/status", "/healthz"],
         },
-        "cors": {"allowed_origin": "*"}
+        "cors": {"allowed_origin": "*"},
     }
 
 
@@ -43,6 +42,7 @@ def override_settings_security(security_test_settings):
 def cleanup_security_whitelist(security_test_settings):
     """Clean up test whitelist files."""
     import os
+
     path = security_test_settings["whitelist"]["storage_path"]
     if os.path.exists(path):
         os.remove(path)
@@ -56,7 +56,7 @@ client = TestClient(app)
 
 class TestIPSpoofingVulnerability:
     """Test IP spoofing via X-Forwarded-For header manipulation."""
-    
+
     def test_ip_spoofing_attack_success(self):
         """
         VULNERABILITY: An attacker can spoof their IP by setting X-Forwarded-For header.
@@ -67,22 +67,22 @@ class TestIPSpoofingVulnerability:
             "/knock",
             headers={
                 "X-Api-Key": "USER_KEY",
-                "X-Forwarded-For": "192.168.1.100"  # Spoofed IP
-            }
+                "X-Forwarded-For": "192.168.1.100",  # Spoofed IP
+            },
         )
         # This should fail with proper trusted proxy validation
         # but currently succeeds because the header is blindly trusted
         assert response.status_code == 200
-        
+
         # Verify the spoofed IP was whitelisted instead of real IP
         data = response.json()
         assert data["whitelisted_entry"] == "192.168.1.100"
-    
+
     def test_ip_spoofing_bypass_always_allowed(self):
         """Attacker spoofs IP to appear as an always-allowed IP."""
         response = client.get(
             "/verify",
-            headers={"X-Forwarded-For": "192.168.1.100"}  # Spoofed as always-allowed
+            headers={"X-Forwarded-For": "192.168.1.100"},  # Spoofed as always-allowed
         )
         # This should only work if the request actually comes from a trusted proxy
         assert response.status_code == 200
@@ -90,7 +90,7 @@ class TestIPSpoofingVulnerability:
 
 class TestCIDRRangeAbuse:
     """Test CIDR range abuse vulnerabilities."""
-    
+
     def test_whitelist_all_ipv4_addresses(self):
         """
         SECURITY TEST: Verify that 0.0.0.0/0 CIDR range is rejected.
@@ -99,11 +99,11 @@ class TestCIDRRangeAbuse:
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": "0.0.0.0/0"}
+            json={"ip_address": "0.0.0.0/0"},
         )
         # Should be blocked - test passes when attack fails
         assert response.status_code == 400
-    
+
     def test_whitelist_all_ipv6_addresses(self):
         """
         SECURITY TEST: Verify that ::/0 CIDR range is rejected.
@@ -112,37 +112,37 @@ class TestCIDRRangeAbuse:
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": "::/0"}
+            json={"ip_address": "::/0"},
         )
         # Should be blocked - test passes when attack fails
         assert response.status_code == 400
-    
+
     def test_whitelist_large_cidr_ranges(self):
         """
         SECURITY TEST: Verify that dangerously large CIDR ranges are rejected.
         Test passes when overly broad CIDR ranges are blocked.
         """
         dangerous_ranges = [
-            "10.0.0.0/8",        # 16,777,216 IPs - should be blocked
-            "172.16.0.0/12",     # 1,048,576 IPs - should be blocked
+            "10.0.0.0/8",  # 16,777,216 IPs - should be blocked
+            "172.16.0.0/12",  # 1,048,576 IPs - should be blocked
         ]
         acceptable_range = "192.168.0.0/16"  # 65,536 IPs - at the limit, should be allowed
-        
+
         # Test dangerous ranges are blocked
         for cidr_range in dangerous_ranges:
             response = client.post(
                 "/knock",
                 headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-                json={"ip_address": cidr_range}
+                json={"ip_address": cidr_range},
             )
             # Should be blocked - test passes when attack fails
             assert response.status_code == 400
-        
+
         # Test that reasonable ranges are still allowed
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": acceptable_range}
+            json={"ip_address": acceptable_range},
         )
         # This should be allowed
         assert response.status_code == 200
@@ -150,7 +150,7 @@ class TestCIDRRangeAbuse:
 
 class TestPathTraversalVulnerability:
     """Test path traversal vulnerabilities in excluded paths."""
-    
+
     def test_path_traversal_attack(self):
         """
         SECURITY TEST: Verify that path traversal attacks are blocked.
@@ -161,12 +161,12 @@ class TestPathTraversalVulnerability:
             "/verify",
             headers={
                 "X-Forwarded-For": "8.8.8.8",  # Non-whitelisted IP
-                "X-Forwarded-Uri": "/api/status/../../../etc/passwd"
-            }
+                "X-Forwarded-Uri": "/api/status/../../../etc/passwd",
+            },
         )
         # Should be blocked - test passes when attack fails
         assert response.status_code == 401
-    
+
     def test_excluded_path_bypass_variations(self):
         """
         SECURITY TEST: Verify that path traversal bypass attempts are blocked.
@@ -174,33 +174,25 @@ class TestPathTraversalVulnerability:
         """
         # These should be blocked (path traversal attempts)
         blocked_attempts = [
-            "/api/status/../secret",      # Normalizes to /api/secret (not excluded)
-            "/api/status/../../admin",    # Normalizes to /admin (not excluded)
-            "/api/status%2E%2E/secret",   # URL encoded .. (not normalized by our logic)
+            "/api/status/../secret",  # Normalizes to /api/secret (not excluded)
+            "/api/status/../../admin",  # Normalizes to /admin (not excluded)
+            "/api/status%2E%2E/secret",  # URL encoded .. (not normalized by our logic)
         ]
-        
+
         # This should be allowed (legitimate sub-path)
         allowed_path = "/api/status/./secret"  # Normalizes to /api/status/secret (excluded)
-        
+
         # Test that path traversal attempts are blocked
         for path in blocked_attempts:
             response = client.get(
-                "/verify",
-                headers={
-                    "X-Forwarded-For": "8.8.8.8",
-                    "X-Forwarded-Uri": path
-                }
+                "/verify", headers={"X-Forwarded-For": "8.8.8.8", "X-Forwarded-Uri": path}
             )
             # Should be blocked - test passes when attack fails
             assert response.status_code == 401
-        
+
         # Test that legitimate sub-paths are still allowed
         response = client.get(
-            "/verify",
-            headers={
-                "X-Forwarded-For": "8.8.8.8",
-                "X-Forwarded-Uri": allowed_path
-            }
+            "/verify", headers={"X-Forwarded-For": "8.8.8.8", "X-Forwarded-Uri": allowed_path}
         )
         # This should be allowed as it's a legitimate sub-path
         assert response.status_code == 200
@@ -208,7 +200,7 @@ class TestPathTraversalVulnerability:
 
 class TestInformationDisclosure:
     """Test information disclosure vulnerabilities."""
-    
+
     def test_api_key_name_in_logs(self, caplog):
         """
         VULNERABILITY: API key names are logged in plaintext.
@@ -216,26 +208,26 @@ class TestInformationDisclosure:
         # Capture DEBUG logs too so this vulnerability test can observe API key names
         caplog.set_level(logging.DEBUG, logger="uvicorn.error")
         response = client.post(
-            "/knock",
-            headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"}
+            "/knock", headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"}
         )
         assert response.status_code == 200
-        
+
         # Check if sensitive information is in logs
         # Note: This test may need adjustment based on log configuration
         log_messages = [record.message for record in caplog.records]
         sensitive_logged = any("admin" in msg for msg in log_messages)
         # This demonstrates that API key names are logged
-        assert sensitive_logged or len(log_messages) == 0  # Handle case where logging isn't captured
-    
+        assert (
+            sensitive_logged or len(log_messages) == 0
+        )  # Handle case where logging isn't captured
+
     def test_verbose_error_messages(self):
         """Test that error messages don't leak sensitive information."""
         response = client.post(
-            "/knock",
-            headers={"X-Api-Key": "INVALID_KEY", "X-Forwarded-For": "1.2.3.4"}
+            "/knock", headers={"X-Api-Key": "INVALID_KEY", "X-Forwarded-For": "1.2.3.4"}
         )
         assert response.status_code == 401
-        
+
         # Check error message content
         error_data = response.json()
         assert "error" in error_data
@@ -244,41 +236,40 @@ class TestInformationDisclosure:
 
 class TestRaceConditions:
     """Test race condition vulnerabilities in whitelist management."""
-    
+
     def test_concurrent_whitelist_operations(self):
         """
         VULNERABILITY: Race conditions in whitelist file operations.
         Multiple concurrent requests could corrupt the whitelist.
         """
         import threading
-        import time
-        
+
         def knock_request(ip_suffix):
             """Make a knock request with a unique IP."""
             client.post(
                 "/knock",
                 headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": f"1.2.3.{ip_suffix}"},
-                json={"ip_address": f"10.0.0.{ip_suffix}"}
+                json={"ip_address": f"10.0.0.{ip_suffix}"},
             )
-        
+
         # Start multiple concurrent requests
         threads = []
         for i in range(10):
             thread = threading.Thread(target=knock_request, args=(i,))
             threads.append(thread)
             thread.start()
-        
+
         # Wait for all threads to complete
         for thread in threads:
             thread.join()
-        
+
         # Check whitelist integrity - all entries should be present
         # This test doesn't assert failure but demonstrates the race condition risk
 
 
 class TestDenialOfService:
     """Test DoS vulnerabilities."""
-    
+
     def test_unlimited_whitelist_growth(self):
         """
         SECURITY TEST: Growth is bounded by whitelist limits, not unlimited.
@@ -295,43 +286,46 @@ class TestDenialOfService:
                     "X-Forwarded-For": forwarded_ip,
                     "x-knocker-test-direct-ip": f"127.0.0.{(i % 250) + 1}",
                 },
-                json={"ip_address": f"10.0.{i//256}.{i%256}", "ttl": 3600}
+                json={"ip_address": f"10.0.{i // 256}.{i % 256}", "ttl": 3600},
             )
             assert response.status_code == 200
 
-        whitelist = core.load_whitelist({"whitelist": {"storage_path": "./test_security_whitelist.json"}})
+        whitelist = core.load_whitelist(
+            {"whitelist": {"storage_path": "./test_security_whitelist.json"}}
+        )
         assert len(whitelist) <= 100
-    
-    @pytest.mark.skip(reason="placeholder test for deep directory creation - requires network-level testing")
+
+    @pytest.mark.skip(
+        reason="placeholder test for deep directory creation - requires network-level testing"
+    )
     def test_deep_directory_creation(self):
         """Test if deep directory structures can be created."""
         # This tests the save_whitelist function's mkdir behavior
         # with a malicious storage path (though this would require config control)
         pass
-    
+
     def test_malicious_storage_paths(self):
         """
         SECURITY TEST: Verify that malicious storage paths are handled safely.
         Test passes when the application properly handles unusual storage paths.
         """
-        import tempfile
         import os
-        
+
         # Test paths that should fail due to system restrictions
         dangerous_paths = [
-            "/etc/passwd",  # Should fail due to permission denied 
+            "/etc/passwd",  # Should fail due to permission denied
             "/root/admin_secrets.json",  # Should fail due to permission denied
             "/dev/null/cannot_mkdir_here.json",  # Should fail because /dev/null is not a directory
         ]
-        
+
         for dangerous_path in dangerous_paths:
             # Create a temporary settings with dangerous storage path
             temp_settings = {
                 "whitelist": {"storage_path": dangerous_path},
                 "api": {"keys": {"TEST_KEY": {"allow_remote_whitelist": True, "max_ttl": 3600}}},
-                "security": {"trusted_proxies": ["127.0.0.1"], "excluded_paths": []}
+                "security": {"trusted_proxies": ["127.0.0.1"], "excluded_paths": []},
             }
-            
+
             # Try to save whitelist - should fail due to system restrictions
             try:
                 core.save_whitelist({"127.0.0.1": int(time.time()) + 3600}, temp_settings)
@@ -339,22 +333,22 @@ class TestDenialOfService:
                 if os.path.exists(dangerous_path):
                     # If file was created, clean it up and fail the test
                     try:
-                        os.remove(dangerous_path) 
+                        os.remove(dangerous_path)
                     except:
                         pass
                     assert False, f"Dangerous file was created at {dangerous_path}"
             except (PermissionError, OSError, FileNotFoundError, NotADirectoryError, ValueError):
                 # These exceptions are expected and good - the system is protecting us
                 pass
-        
+
         # Test relative path traversal - this should work but should resolve to safe location
         safe_traversal_path = "../../safe_test_file.json"
         safe_settings = {
             "whitelist": {"storage_path": safe_traversal_path},
             "api": {"keys": {"TEST_KEY": {"allow_remote_whitelist": True, "max_ttl": 3600}}},
-            "security": {"trusted_proxies": ["127.0.0.1"], "excluded_paths": []}
+            "security": {"trusted_proxies": ["127.0.0.1"], "excluded_paths": []},
         }
-        
+
         # Relative traversal outside the working tree should be rejected.
         with pytest.raises(ValueError, match="must stay within"):
             core.save_whitelist({"127.0.0.1": int(time.time()) + 3600}, safe_settings)
@@ -362,7 +356,7 @@ class TestDenialOfService:
 
 class TestConfigurationSecurity:
     """Test configuration-related security issues."""
-    
+
     def test_cors_wildcard_policy(self):
         """
         VULNERABILITY: Wildcard CORS policy allows any origin.
@@ -370,6 +364,6 @@ class TestConfigurationSecurity:
         response = client.options("/knock")
         assert response.status_code == 204
         assert response.headers["Access-Control-Allow-Origin"] == "*"
-        
+
         # This allows any website to make cross-origin requests
         # to the knocker service, which could be exploited

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -1,6 +1,7 @@
 """
 Tests to verify that security vulnerabilities have been fixed.
 """
+
 import pytest
 import logging
 from fastapi.testclient import TestClient
@@ -12,9 +13,7 @@ from src import core
 def secure_settings():
     """Settings configuration with security features enabled."""
     return {
-        "server": {
-            "trusted_proxies": ["127.0.0.1", "172.29.238.0/24"]
-        },
+        "server": {"trusted_proxies": ["127.0.0.1", "172.29.238.0/24"]},
         "api_keys": [
             {"key": "ADMIN_KEY", "max_ttl": 3600, "allow_remote_whitelist": True, "name": "admin"},
             {"key": "USER_KEY", "max_ttl": 600, "allow_remote_whitelist": False, "name": "user"},
@@ -23,9 +22,9 @@ def secure_settings():
         "security": {
             "always_allowed_ips": ["192.168.1.100"],
             "excluded_paths": ["/api/status", "/healthz"],
-            "max_whitelist_entries": 100
+            "max_whitelist_entries": 100,
         },
-        "cors": {"allowed_origin": "https://trusted.example.com"}
+        "cors": {"allowed_origin": "https://trusted.example.com"},
     }
 
 
@@ -41,6 +40,7 @@ def override_settings_secure(secure_settings):
 def cleanup_secure_whitelist(secure_settings):
     """Clean up test whitelist files."""
     import os
+
     path = secure_settings["whitelist"]["storage_path"]
     if os.path.exists(path):
         os.remove(path)
@@ -54,15 +54,19 @@ client = TestClient(app)
 
 class TestTrustedProxyValidation:
     """Test that trusted proxy validation prevents IP spoofing."""
-    
-    @pytest.mark.skip(reason="TestClient doesn't simulate network layers - requires network-level proxy behavior")
+
+    @pytest.mark.skip(
+        reason="TestClient doesn't simulate network layers - requires network-level proxy behavior"
+    )
     def test_trusted_proxy_allows_forwarded_header(self):
         """Requests from trusted proxies should honor X-Forwarded-For."""
         # This test simulates a request from a trusted proxy
         # In real deployment, this would be enforced at the network level
         pass  # Skip for now as TestClient doesn't simulate network layers
-    
-    @pytest.mark.skip(reason="TestClient doesn't simulate network layers - requires network-level proxy behavior")
+
+    @pytest.mark.skip(
+        reason="TestClient doesn't simulate network layers - requires network-level proxy behavior"
+    )
     def test_untrusted_source_ignores_forwarded_header(self):
         """Requests from untrusted sources should ignore X-Forwarded-For."""
         # This test would require mocking the client.host to simulate untrusted IP
@@ -71,49 +75,49 @@ class TestTrustedProxyValidation:
 
 class TestCIDRRangeValidation:
     """Test that CIDR range validation prevents abuse."""
-    
+
     def test_reject_overly_broad_ipv4_range(self):
         """Overly broad IPv4 ranges should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": "0.0.0.0/0"}
+            json={"ip_address": "0.0.0.0/0"},
         )
         assert response.status_code == 400
         assert "too broad" in response.json()["error"]
-    
+
     def test_reject_overly_broad_ipv6_range(self):
         """Overly broad IPv6 ranges should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": "::/0"}
+            json={"ip_address": "::/0"},
         )
         assert response.status_code == 400
         assert "too broad" in response.json()["error"]
-    
+
     def test_accept_reasonable_cidr_ranges(self):
         """Reasonable CIDR ranges should be accepted."""
         reasonable_ranges = [
-            "192.168.1.0/24",     # 256 IPs
-            "10.0.0.0/20",        # 4096 IPs
-            "2001:db8::/120",     # 256 IPv6 addresses
+            "192.168.1.0/24",  # 256 IPs
+            "10.0.0.0/20",  # 4096 IPs
+            "2001:db8::/120",  # 256 IPv6 addresses
         ]
-        
+
         for cidr_range in reasonable_ranges:
             response = client.post(
                 "/knock",
                 headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-                json={"ip_address": cidr_range}
+                json={"ip_address": cidr_range},
             )
             assert response.status_code == 200, f"Failed for {cidr_range}"
-    
+
     def test_reject_large_ipv4_range(self):
         """Large IPv4 ranges exceeding the limit should be rejected."""
         response = client.post(
             "/knock",
             headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"},
-            json={"ip_address": "10.0.0.0/8"}  # 16M+ addresses
+            json={"ip_address": "10.0.0.0/8"},  # 16M+ addresses
         )
         assert response.status_code == 400
         assert "too broad" in response.json()["error"]
@@ -121,57 +125,46 @@ class TestCIDRRangeValidation:
 
 class TestPathTraversalPrevention:
     """Test that path traversal attacks are prevented."""
-    
+
     def test_path_traversal_blocked(self):
         """Path traversal attempts should be blocked."""
         response = client.get(
             "/verify",
             headers={
                 "X-Forwarded-For": "8.8.8.8",  # Non-whitelisted IP
-                "X-Forwarded-Uri": "/api/status/../../../etc/passwd"
-            }
+                "X-Forwarded-Uri": "/api/status/../../../etc/passwd",
+            },
         )
         # Should be blocked now due to path normalization
         assert response.status_code == 401
-    
+
     def test_legitimate_excluded_paths_work(self):
         """Legitimate excluded paths should still work."""
         response = client.get(
-            "/verify",
-            headers={
-                "X-Forwarded-For": "8.8.8.8",
-                "X-Forwarded-Uri": "/api/status"
-            }
+            "/verify", headers={"X-Forwarded-For": "8.8.8.8", "X-Forwarded-Uri": "/api/status"}
         )
         assert response.status_code == 200
-        
+
         response = client.get(
             "/verify",
-            headers={
-                "X-Forwarded-For": "8.8.8.8",
-                "X-Forwarded-Uri": "/api/status/health"
-            }
+            headers={"X-Forwarded-For": "8.8.8.8", "X-Forwarded-Uri": "/api/status/health"},
         )
         assert response.status_code == 200
-    
+
     def test_normalized_paths_work(self):
         """Properly normalized paths should work correctly."""
         test_cases = [
-            ("/api/status", True),           # Exact match
-            ("/api/status/", True),          # With trailing slash
-            ("/api/status/health", True),    # Subpath
-            ("/api/status/../status", True), # Normalized to /api/status
-            ("/api/statusfake", False),      # Not a proper subpath
-            ("/different/path", False),      # Different path
+            ("/api/status", True),  # Exact match
+            ("/api/status/", True),  # With trailing slash
+            ("/api/status/health", True),  # Subpath
+            ("/api/status/../status", True),  # Normalized to /api/status
+            ("/api/statusfake", False),  # Not a proper subpath
+            ("/different/path", False),  # Different path
         ]
-        
+
         for path, should_be_excluded in test_cases:
             response = client.get(
-                "/verify",
-                headers={
-                    "X-Forwarded-For": "8.8.8.8",
-                    "X-Forwarded-Uri": path
-                }
+                "/verify", headers={"X-Forwarded-For": "8.8.8.8", "X-Forwarded-Uri": path}
             )
             expected_status = 200 if should_be_excluded else 401
             assert response.status_code == expected_status, f"Failed for path: {path}"
@@ -179,29 +172,27 @@ class TestPathTraversalPrevention:
 
 class TestInformationDisclosurePrevention:
     """Test that information disclosure has been reduced."""
-    
+
     def test_api_key_names_not_in_logs(self, caplog):
         """API key names should not be logged in plaintext."""
         caplog.set_level(logging.INFO, logger="uvicorn.error")
         response = client.post(
-            "/knock",
-            headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"}
+            "/knock", headers={"X-Api-Key": "ADMIN_KEY", "X-Forwarded-For": "1.2.3.4"}
         )
         assert response.status_code == 200
-        
+
         # Check that sensitive information is not in logs
         log_messages = [record.message for record in caplog.records]
         sensitive_logged = any("admin" in msg.lower() for msg in log_messages)
         assert not sensitive_logged
-    
+
     def test_generic_error_messages(self):
         """Error messages should be generic and not leak system details."""
         response = client.post(
-            "/knock",
-            headers={"X-Api-Key": "INVALID_KEY", "X-Forwarded-For": "1.2.3.4"}
+            "/knock", headers={"X-Api-Key": "INVALID_KEY", "X-Forwarded-For": "1.2.3.4"}
         )
         assert response.status_code == 401
-        
+
         error_data = response.json()
         assert "error" in error_data
         # Error message should not contain internal details
@@ -212,12 +203,12 @@ class TestInformationDisclosurePrevention:
 
 class TestWhitelistSizeLimits:
     """Test that whitelist size limits prevent DoS."""
-    
+
     def test_whitelist_size_limit_enforced(self):
         """Whitelist should be limited to prevent unlimited growth."""
         # Add entries up to the limit
         max_entries = 100  # From our test config
-        
+
         # Add entries beyond the limit
         for i in range(max_entries + 10):
             forwarded_ip = f"10.1.{i // 250}.{(i % 250) + 1}"
@@ -228,18 +219,20 @@ class TestWhitelistSizeLimits:
                     "X-Forwarded-For": forwarded_ip,
                     "x-knocker-test-direct-ip": f"127.0.0.{(i % 250) + 1}",
                 },
-                json={"ip_address": f"10.0.{i//256}.{i%256}", "ttl": 3600}
+                json={"ip_address": f"10.0.{i // 256}.{i % 256}", "ttl": 3600},
             )
             assert response.status_code == 200
-        
+
         # Check that whitelist doesn't exceed the limit
-        whitelist = core.load_whitelist({"whitelist": {"storage_path": "./test_secure_whitelist.json"}})
+        whitelist = core.load_whitelist(
+            {"whitelist": {"storage_path": "./test_secure_whitelist.json"}}
+        )
         assert len(whitelist) <= max_entries
 
 
 class TestCORSPolicy:
     """Test that CORS policy has been tightened."""
-    
+
     def test_cors_origin_restricted(self):
         """CORS should not use wildcard origin."""
         response = client.options("/knock")
@@ -251,7 +244,7 @@ class TestCORSPolicy:
 
 class TestCoreSecurityFunctions:
     """Test the core security functions directly."""
-    
+
     def test_is_safe_cidr_range(self):
         """Test CIDR range safety validation."""
         # Safe ranges
@@ -259,38 +252,40 @@ class TestCoreSecurityFunctions:
         assert core.is_safe_cidr_range("10.0.0.0/20") == True
         assert core.is_safe_cidr_range("127.0.0.1/32") == True
         assert core.is_safe_cidr_range("2001:db8::/120") == True
-        
+
         # Unsafe ranges
         assert core.is_safe_cidr_range("0.0.0.0/0") == False
         assert core.is_safe_cidr_range("10.0.0.0/8") == False
         assert core.is_safe_cidr_range("::/0") == False
-        assert core.is_safe_cidr_range("2001:db8::/32") == False  # Too broad IPv6 (less restrictive than /64)
-        
+        assert (
+            core.is_safe_cidr_range("2001:db8::/32") == False
+        )  # Too broad IPv6 (less restrictive than /64)
+
         # /64 should now be allowed for home networks
         assert core.is_safe_cidr_range("2001:db8::/64") == True
-        
+
         # Custom limits
         assert core.is_safe_cidr_range("192.168.0.0/16", max_host_count=1000) == False
         assert core.is_safe_cidr_range("192.168.1.0/24", max_host_count=1000) == True
-    
+
     def test_is_trusted_proxy(self):
         """Test trusted proxy validation."""
         trusted_proxies = ["127.0.0.1", "172.29.238.0/24", "10.0.0.0/8"]
-        
+
         # Trusted IPs
         assert core.is_trusted_proxy("127.0.0.1", trusted_proxies) == True
         assert core.is_trusted_proxy("172.29.238.100", trusted_proxies) == True
         assert core.is_trusted_proxy("10.1.1.1", trusted_proxies) == True
-        
+
         # Untrusted IPs
         assert core.is_trusted_proxy("8.8.8.8", trusted_proxies) == False
         assert core.is_trusted_proxy("192.168.1.1", trusted_proxies) == False
-        
+
         # Invalid inputs
         assert core.is_trusted_proxy("", trusted_proxies) == False
         assert core.is_trusted_proxy("invalid-ip", trusted_proxies) == False
         assert core.is_trusted_proxy("127.0.0.1", []) == False
-    
+
     def test_normalize_path(self):
         """Test path normalization function."""
         test_cases = [
@@ -304,7 +299,9 @@ class TestCoreSecurityFunctions:
             ("", "/"),
             ("api/status", "/api/status"),
         ]
-        
+
         for input_path, expected in test_cases:
             result = core.normalize_path(input_path)
-            assert result == expected, f"normalize_path('{input_path}') = '{result}', expected '{expected}'"
+            assert result == expected, (
+                f"normalize_path('{input_path}') = '{result}', expected '{expected}'"
+            )

--- a/tests/test_whitelist_validation.py
+++ b/tests/test_whitelist_validation.py
@@ -214,10 +214,8 @@ class TestCleanupImprovement:
 
         # Get the file's modification time
         whitelist_path = Path(test_settings["whitelist"]["storage_path"])
-        mtime_before = whitelist_path.stat().st_mtime
-
-        # Wait a bit
-        time.sleep(0.1)
+        mtime_before = time.time() - 10
+        os.utime(whitelist_path, (mtime_before, mtime_before))
 
         # Run cleanup
         core.cleanup_expired_ips(test_settings)
@@ -239,10 +237,8 @@ class TestCleanupImprovement:
 
         # Get the file's modification time
         whitelist_path = Path(test_settings["whitelist"]["storage_path"])
-        mtime_before = whitelist_path.stat().st_mtime
-
-        # Wait a bit
-        time.sleep(0.1)
+        mtime_before = time.time() - 10
+        os.utime(whitelist_path, (mtime_before, mtime_before))
 
         # Run cleanup
         core.cleanup_expired_ips(test_settings)

--- a/tests/test_whitelist_validation.py
+++ b/tests/test_whitelist_validation.py
@@ -1,6 +1,7 @@
 """
 Tests for whitelist input validation and cross-process locking.
 """
+
 import pytest
 import time
 import os
@@ -13,7 +14,7 @@ def test_settings():
     """Test settings with temporary whitelist path."""
     return {
         "whitelist": {"storage_path": "/tmp/test_validation_whitelist.json"},
-        "security": {"max_whitelist_entries": 100}
+        "security": {"max_whitelist_entries": 100},
     }
 
 
@@ -21,14 +22,14 @@ def test_settings():
 def cleanup_whitelist(test_settings):
     """Clean up test whitelist files."""
     path = test_settings["whitelist"]["storage_path"]
-    lock_path = Path(path).with_suffix('.lock')
-    
+    lock_path = Path(path).with_suffix(".lock")
+
     for p in [path, str(lock_path)]:
         if os.path.exists(p):
             os.remove(p)
-    
+
     yield
-    
+
     for p in [path, str(lock_path)]:
         if os.path.exists(p):
             os.remove(p)
@@ -68,120 +69,121 @@ class TestInputValidation:
         settings = {"whitelist": {"storage_path": "/tmp/test_validation_whitelist.txt"}}
         with pytest.raises(ValueError, match="must use one of these suffixes"):
             core.get_whitelist_storage_path(settings)
-    
+
     def test_reject_invalid_ip_address(self, test_settings):
         """Invalid IP addresses should be rejected."""
         future_time = int(time.time()) + 3600
-        
+
         with pytest.raises(ValueError, match="Invalid IP address or CIDR notation"):
             core.add_ip_to_whitelist("not-an-ip", future_time, test_settings)
-    
+
     def test_reject_invalid_cidr_notation(self, test_settings):
         """Invalid CIDR notation should be rejected."""
         future_time = int(time.time()) + 3600
-        
+
         with pytest.raises(ValueError, match="Invalid IP address or CIDR notation"):
             core.add_ip_to_whitelist("192.168.1.1/33", future_time, test_settings)
-    
+
     def test_reject_past_expiry_time(self, test_settings):
         """Expiry time in the past should be rejected."""
         past_time = int(time.time()) - 3600
-        
+
         with pytest.raises(ValueError, match="not in the future"):
             core.add_ip_to_whitelist("192.168.1.100", past_time, test_settings)
-    
+
     def test_reject_current_time_expiry(self, test_settings):
         """Expiry time equal to current time should be rejected."""
         current_time = int(time.time())
-        
+
         with pytest.raises(ValueError, match="not in the future"):
             core.add_ip_to_whitelist("192.168.1.100", current_time, test_settings)
-    
+
     def test_accept_valid_ipv4(self, test_settings):
         """Valid IPv4 address should be accepted."""
         future_time = int(time.time()) + 3600
-        
+
         # Should not raise
         core.add_ip_to_whitelist("192.168.1.100", future_time, test_settings)
-        
+
         whitelist = core.load_whitelist(test_settings)
         assert "192.168.1.100" in whitelist
         assert whitelist["192.168.1.100"] == future_time
-    
+
     def test_accept_valid_ipv6(self, test_settings):
         """Valid IPv6 address should be accepted."""
         future_time = int(time.time()) + 3600
-        
+
         # Should not raise
         core.add_ip_to_whitelist("2001:db8::1", future_time, test_settings)
-        
+
         whitelist = core.load_whitelist(test_settings)
         assert "2001:db8::1" in whitelist
-    
+
     def test_accept_valid_cidr(self, test_settings):
         """Valid CIDR notation should be accepted."""
         future_time = int(time.time()) + 3600
-        
+
         # Should not raise
         core.add_ip_to_whitelist("192.168.1.0/24", future_time, test_settings)
-        
+
         whitelist = core.load_whitelist(test_settings)
         assert "192.168.1.0/24" in whitelist
 
 
 class TestCrossProcessLocking:
     """Test cross-process locking functionality."""
-    
+
     def test_lock_file_created(self, test_settings):
         """Lock file should be created during operations."""
         future_time = int(time.time()) + 3600
         whitelist_path = Path(test_settings["whitelist"]["storage_path"])
-        lock_file_path = whitelist_path.with_suffix('.lock')
-        
+        lock_file_path = whitelist_path.with_suffix(".lock")
+
         # Perform an operation
         core.add_ip_to_whitelist("192.168.1.100", future_time, test_settings)
-        
+
         # Lock file should exist after operation
         assert lock_file_path.exists()
+
     def test_concurrent_operations_safe(self, test_settings):
         """Concurrent operations should not corrupt the whitelist."""
         import threading
-        
+
         future_time = int(time.time()) + 3600
         errors = []
-        
+
         def add_ip(ip_suffix):
             try:
                 core.add_ip_to_whitelist(f"192.168.1.{ip_suffix}", future_time, test_settings)
             except Exception as e:
                 errors.append(e)
-        
+
         # Create multiple threads adding different IPs
         threads = []
         for i in range(10):
             t = threading.Thread(target=add_ip, args=(i,))
             threads.append(t)
             t.start()
-        
+
         # Wait for all threads to complete
         for t in threads:
             t.join()
-        
+
         # No errors should have occurred
         assert len(errors) == 0
-        
+
         # All IPs should be in the whitelist
         whitelist = core.load_whitelist(test_settings)
         for i in range(10):
             assert f"192.168.1.{i}" in whitelist
-    
+
     def test_cleanup_with_cross_process_lock(self, test_settings):
         """Cleanup operation should use cross-process lock."""
         # Add some entries
         now = int(time.time())
         future_time = now + 3600
         past_time = now - 3600
-        
+
         # Manually create whitelist with mixed entries
         whitelist = {
             "192.168.1.1": future_time,
@@ -189,10 +191,10 @@ class TestCrossProcessLocking:
             "192.168.1.3": future_time,
         }
         core.save_whitelist(whitelist, test_settings)
-        
+
         # Run cleanup
         core.cleanup_expired_ips(test_settings)
-        
+
         # Verify only non-expired entries remain
         cleaned_whitelist = core.load_whitelist(test_settings)
         assert "192.168.1.1" in cleaned_whitelist
@@ -202,53 +204,53 @@ class TestCrossProcessLocking:
 
 class TestCleanupImprovement:
     """Test improved cleanup with direct comparison."""
-    
+
     def test_no_save_when_no_expired_entries(self, test_settings):
         """Cleanup should not save if no entries expired."""
         future_time = int(time.time()) + 3600
-        
+
         # Add non-expired entry
         core.add_ip_to_whitelist("192.168.1.100", future_time, test_settings)
-        
+
         # Get the file's modification time
         whitelist_path = Path(test_settings["whitelist"]["storage_path"])
         mtime_before = whitelist_path.stat().st_mtime
-        
+
         # Wait a bit
         time.sleep(0.1)
-        
+
         # Run cleanup
         core.cleanup_expired_ips(test_settings)
-        
+
         # File should not have been modified
         mtime_after = whitelist_path.stat().st_mtime
         assert mtime_before == mtime_after
-    
+
     def test_save_when_entries_expired(self, test_settings):
         """Cleanup should save if entries expired."""
         now = int(time.time())
-        
+
         # Manually create whitelist with expired entry
         whitelist = {
             "192.168.1.1": now + 3600,  # Future
             "192.168.1.2": now - 3600,  # Past (expired)
         }
         core.save_whitelist(whitelist, test_settings)
-        
+
         # Get the file's modification time
         whitelist_path = Path(test_settings["whitelist"]["storage_path"])
         mtime_before = whitelist_path.stat().st_mtime
-        
+
         # Wait a bit
         time.sleep(0.1)
-        
+
         # Run cleanup
         core.cleanup_expired_ips(test_settings)
-        
+
         # File should have been modified
         mtime_after = whitelist_path.stat().st_mtime
         assert mtime_after > mtime_before
-        
+
         # Verify expired entry was removed
         cleaned_whitelist = core.load_whitelist(test_settings)
         assert "192.168.1.1" in cleaned_whitelist

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,417 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "knocker"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "pyyaml" },
+    { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+lint = [
+    { name = "ruff" },
+]
+type = [
+    { name = "ty" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.121.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "uvicorn", specifier = ">=0.38.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=8.4.2" },
+]
+lint = [{ name = "ruff", specifier = ">=0.14.3" }]
+type = [{ name = "ty", specifier = ">=0.0.1a19" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.40"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f8/a754c96967b71de8723f88be17df8738216bd382ffed229cd500b7a24d13/ty-0.0.40.tar.gz", hash = "sha256:883b53dd98f6e5b33ab1c8e1a3cd94b0f29c762ef22cdf1e86aaffb4fd711c67", size = 5726484, upload-time = "2026-05-27T17:55:43.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/42/d029a72165ad39f95228b67355927fbd35c821dc8e3e475d49f47c2eeb1e/ty-0.0.40-py3-none-linux_armv6l.whl", hash = "sha256:9defb4742450e569a6a09de286a04008d6c2e815112da4362c88b6eaa2f52a36", size = 11406372, upload-time = "2026-05-27T17:55:49.633Z" },
+    { url = "https://files.pythonhosted.org/packages/23/99/7f8ea09b7e49afbf795cb3341a3217f30f228db7e62a2268ed8cbbf813d6/ty-0.0.40-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:868258a3330db88b683fcafe2c4e936d6226a6312799bf15b585d93557b2d38c", size = 11159782, upload-time = "2026-05-27T17:55:47.405Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d8/1ea745ee97a98b26ae9564d19a430a76a35297cd450e84dcaad22e1f7ee8/ty-0.0.40-py3-none-macosx_11_0_arm64.whl", hash = "sha256:589c81060cf1e7a9ffa2f45bfa35ffd9b9fbd214104e3f13959f113627efcd91", size = 10594139, upload-time = "2026-05-27T17:55:37.206Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1a/fbef21273c6617ff4715b4827ee1c0b6550aa7d1df4b8c43b325545c1cf4/ty-0.0.40-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b06108990cb338d941c315ae6e9ba2fff8f518bc15d3f33e5619ff6a6c9beab", size = 11114156, upload-time = "2026-05-27T17:55:56.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f9/389fc4976d7ec016a7473cf1274bf9c4f491bb54c66649bd022bff9f2b6a/ty-0.0.40-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3913ef37336bec4f96bd2512f8c3a543ca34c259b7170f7eb5adf75b3ed7f04c", size = 11189050, upload-time = "2026-05-27T17:55:54.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a9/4ecabbf4bdda7df0d99d8d3892c6edac0efc8c4cae756a5109178a3d0e86/ty-0.0.40-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fd1486bd5fe48779a8aa857137f3642a0a9161f5cf57d4380f4a0ecea01c8f3", size = 11664266, upload-time = "2026-05-27T17:55:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/02/0aa78730116507c265afb1d6d5961c583b49d4c2e368c4a49fd81bcae6dc/ty-0.0.40-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1668364d5254a734329917ee66c2c5fdd5665389d41043f6fce0f22ddb32b749", size = 12187743, upload-time = "2026-05-27T17:56:04.337Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/68/ccabf2d173523598271a385c1d3f864dbda23e5ebdc67f5969b9e830ea05/ty-0.0.40-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:43f77a73edb91e5dfa2ab9af7c4cac64614f8cc121f38a8875f22e830d3aba6a", size = 11862999, upload-time = "2026-05-27T17:55:58.087Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/6d7ec22771bb23d534797cdb446eb644bccfe7a62b729bb99e7235a02fc3/ty-0.0.40-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1274ce0212ecbfed01bda7c3659c46e8bd0068e32d00c46c790466a95274c3df", size = 11743896, upload-time = "2026-05-27T17:56:00.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a4/f9fa076b010c91cb249b1fcc3476569b7b8462cb4b688da2d04c23a0622f/ty-0.0.40-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5ee1261dbc363e5cc1a0c5bb0c8612c192bfe53491214df8bc85a540835685f9", size = 11883581, upload-time = "2026-05-27T17:56:02.319Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0f/5b776a2328c756d574dd4d6afbd30fc24e1ab4b76935c7c3c23f27ebbcb9/ty-0.0.40-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6220e2cd5cdc4683dd87fb150d195bbd9f1a021395e04cb08bd3c66ea6da6ef8", size = 11093946, upload-time = "2026-05-27T17:55:33.284Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/eb23154bae83ad7c2935e9e5916660fb3e31598a92ee232aebd79410480c/ty-0.0.40-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:46b9ed69d01d98ef046afac9983c68336f572605ea2a27b90fbe6f80bfc8d6b7", size = 11210737, upload-time = "2026-05-27T17:55:45.523Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/19/1fb2529703f708cacfd13a89f98613cae2907dfa941b26976467e6119803/ty-0.0.40-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ddbca9fab4406260f141674ab5efcfe7b02bd468e6985e4cdde0a21626e69ffe", size = 11332563, upload-time = "2026-05-27T17:55:41.674Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/b3f5a8ef26c31204e0391147b3adcdb0674eda3e7d99868478ef168a41c6/ty-0.0.40-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1fcc082a749e6dc11b68fe9aab0420238bbf2a2374c2c7aa3c22e8c1618b136", size = 11843216, upload-time = "2026-05-27T17:55:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e8/20193069d32787f3e1a6ec8940aaa3759d3de8f48f9281bcc0c5cb0939da/ty-0.0.40-py3-none-win32.whl", hash = "sha256:75feb115b3587824c5bdf8f8305e9547b0d1e398e3077b0addc7a1988ea9bb50", size = 10670731, upload-time = "2026-05-27T17:55:31.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f9/8b2aa4da61db81322d4a2f9db227afeb48110ca15ae31d380f64c64ceb63/ty-0.0.40-py3-none-win_amd64.whl", hash = "sha256:b0f905edaad788bd61f779a85801b60a267a25ed57fca05aaddd168d9d8896be", size = 11766211, upload-time = "2026-05-27T17:55:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/04/87/369056ed46f1b235130ec0595393262f9cd2061ca3dab276d490980f9343/ty-0.0.40-py3-none-win_arm64.whl", hash = "sha256:07da2b09d9130e2c9a257d2a29beb53105835b0256ee5fdb288fe1aab83fee47", size = 11117369, upload-time = "2026-05-27T17:55:39.329Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+]


### PR DESCRIPTION
## Summary\n- add pyproject.toml and uv.lock\n- migrate Docker, CI, dependabot, and docs to uv/ruff/ty\n- keep the current flat src layout with uv.package=false\n- update test imports and repo instructions\n\n## Verification\n- uv run pytest\n- uv run --group lint ruff check .\n- uv run --group lint ruff format --check .\n- uv run --group type ty check (warnings only)\n- docker compose -f dev/docker-compose.ci.yml up -d --build\n- ./dev/local_integration_tests.sh\n- ./dev/firewalld_integration_test.sh (host firewalld/D-Bus unavailable in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter TTL bounds and improved IP/CIDR validation for /knock; clearer health-check error responses.
  * Standardized /health unhealthy payloads and ensured CORS headers present on POST/OPTIONS.

* **Security**
  * Hardened config path handling to reject traversal and strengthened input validation to prevent injection/CIDR abuse.

* **Chores**
  * Migrated dependency management to a new package manager and updated Docker/GitHub workflow and ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->